### PR TITLE
Documentation fix, addition of an additional device

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ This tool provides an interactive shell where you can execute commands in
 Download Mode. To enter this mode:
 
  1. Power off the phone.
- 2. Press and hold **Volume up**.
- 3. Connect the phone to a computer using a USB cable.
- 4. Wait for the **Download mode** screen to appear.
- 5. Release keys. You should now see a **Firmware Update** screen.
+ 2. Connect the phone to a computer using a USB cable.
+ 3. Press and hold **Volume up**.
+ 4. Briefly press the power button.
+ 5. Wait for the **Download mode** screen to appear.
+ 6. Release keys. You should now see a **Firmware Update** screen.
 
 Now you can issue commands using the interactive shell:
 

--- a/lglaf.lua
+++ b/lglaf.lua
@@ -95,7 +95,7 @@ end
 
 function lglaf.init()
     local usb_product = DissectorTable.get("usb.product");
-    usb_product:add(0x1004633e, lglaf) -- LG G3 D855
-    usb_product:add(0x1004627f, lglaf) -- LG G3 VS985
-    usb_product:add(0x10046298, lglaf) -- LG G4 VS986
+    usb_product:add(0x1004633e, lglaf) -- LG G3 (D855) or LG V10 (H962)
+    usb_product:add(0x1004627f, lglaf) -- LG G3 (VS985)
+    usb_product:add(0x10046298, lglaf) -- LG G4 (VS986)
 end

--- a/rules.d/42-usb-lglaf.rules
+++ b/rules.d/42-usb-lglaf.rules
@@ -5,3 +5,5 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633e", TAG+="uacce
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="627f", TAG+="uaccess"
 # LG G4 (VS986) in download mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="6298", TAG+="uaccess"
+# LG V10 (H962) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633e", TAG+="uaccess"

--- a/rules.d/42-usb-lglaf.rules
+++ b/rules.d/42-usb-lglaf.rules
@@ -1,9 +1,7 @@
 # /etc/udev/rules.d/42-usb-lglaf.rules
-# LG G3 (D855) in download mode
+# LG G3 (D855) or LG V10 (H962) in download mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633e", TAG+="uaccess"
 # LG G3 (VS985) in download mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="627f", TAG+="uaccess"
 # LG G4 (VS986) in download mode
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="6298", TAG+="uaccess"
-# LG V10 (H962) in download mode
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633e", TAG+="uaccess"


### PR DESCRIPTION
The README.md's instructions for download mode were a bit funky, I think this is better.

Add one of the LG V10 (H962) devices.  This device needs issue #7 fixed before this tool is really helpful, but since I've got the data.