### PR TITLE
fix unwanted CRLF conversion on windows

### DIFF
--- a/lglaf.py
+++ b/lglaf.py
@@ -373,6 +373,9 @@ def main():
             level=logging.DEBUG if args.debug else logging.INFO)
 
     # Binary stdout (output data from device as-is)
+    if sys.platform == "win32":
+        import os, msvcrt
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
     try: stdout_bin = sys.stdout.buffer
     except: stdout_bin = sys.stdout
 


### PR DESCRIPTION
python 2.x does CRLF conversion on windows by default, causing my READs to be damaged.

Took my fix from http://stackoverflow.com/questions/2374427/python-2-x-write-binary-output-to-stdout