### PR TITLE
add challenge/response

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ allows you to execute arbitrary shell commands on a LG phone as root.
 
 Contents of this repository:
 
+ - [auth.py](auth.py) - challenge/response on newer devices (see below).
  - [lglaf.py](lglaf.py) - main script for communication (see below).
  - [partitions.py](partitions.py) - manage (list / read / write) partitions.
  - [extract-partitions.py](extract-partitions.py) - Dump all partitions
@@ -35,6 +36,7 @@ Tested with:
  - LG G3 (D855) on 32-bit Windows XP (Python 3.4.4, LG drivers).
  - LG G2 (VS985).
  - LG G4 (VS986) on Linux (Python 3.5) and Windows.
+ - LG G4 (H810,H811,H812,H815) on 64 bit Arch Linux | FWUL (Python 2.7.13, pyusb 1.0.0-5, libusb 1.0.21-2)
 
 ## Usage
 This tool provides an interactive shell where you can execute commands in
@@ -59,6 +61,13 @@ Now you can issue commands using the interactive shell:
     # cat /proc/version
     Linux version 3.4.0-perf-gf95c7ee (lgmobile@LGEARND12B2) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Tue Aug 18 19:25:04 KST 2015
     # exit
+
+Some devices require a challenge/response before communication is possible (only needed once after entering download mode):
+
+    (venv)[peter@al lglaf]$ python auth.py --debug
+    LGLAF.py: DEBUG: Using endpoints 83 (IN), 02 (OUT)
+    auth: DEBUG: Challenge: c4:af:ff:aa
+    auth: DEBUG: Response: 12:7a:c2:c2:87:0e:06:5d:a2:a4:c3:8c:a2:12:12:12
 
 When commands are piped to stdin (or given via `-c`), the prompt is hidden:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Tested with:
  - LG G3 (D855) on 32-bit Windows XP (Python 3.4.4, LG drivers).
  - LG G2 (VS985).
  - LG G4 (VS986) on Linux (Python 3.5) and Windows.
- - LG G4 (H810,H811,H812,H815) on 64 bit Arch Linux | FWUL (Python 2.7.13, pyusb 1.0.0-5, libusb 1.0.21-2)
+ - LG G4 (H810,H811,H812,H815) on 64 bit Arch Linux | [FWUL](https://tinyurl.com/FWULatXDA) (Python 2.7.13, pyusb 1.0.0-5, libusb 1.0.21-2)
 
 ## Usage
 This tool provides an interactive shell where you can execute commands in

--- a/auth.py
+++ b/auth.py
@@ -46,10 +46,12 @@ def do_challenge_response(comm):
     kilo_challenge = kilo_header[8:12]
     chalstring = ":".join("{:02x}".format(ord(k)) for k in kilo_challenge)
     _logger.debug("Challenge: %s" %chalstring)
+    print("Challenge: %s" %chalstring)
     key2 = b'qndiakxxuiemdklseqid~a~niq,zjuxl' # if this doesnt work try 'lgowvqnltpvtgogwswqn~n~mtjjjqxro'
     kilo_response = do_aes_encrypt(key_xoring(key_transform(key2), kilo_challenge))
     respstring = ":".join("{:02x}".format(ord(m)) for m in kilo_response)
-    _logger.debug("Response: %s" %respstring)
+    #_logger.debug("Response: %s" %respstring)
+    print("Response: %s" %respstring)
     request_kilo_metr =  lglaf.make_request(b'KILO', args=[b'METR', b'\0\0\0\0', b'\x02\0\0\0', b'\0\0\0\0'], body=bytes(kilo_response))
     metr_header, metr_response = comm.call(request_kilo_metr)
 

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Challenge/Response for communication with LG devices in download mode (LAF).
+#
+# Copyright (C) 2015 Peter Wu <peter@lekensteyn.nl>
+# Licensed under the MIT license <http://opensource.org/licenses/MIT>.
+
+from Crypto.Cipher import AES
+from contextlib import closing, contextmanager
+import lglaf,argparse,logging,struct
+
+_logger = logging.getLogger("auth")
+
+parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(description='LG LAF Download Mode utility')
+parser.add_argument("--auth", action="store_true", help="auth LAF")
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+
+def key_transform(old_key):
+    new_key = ''
+    for x in range(32,0,-1):
+        new_key += chr(ord(old_key[x-1]) - (x % 0x0C))
+    return new_key
+
+def key_xoring(key2_t, kilo_challenge):
+    key2_t_xor = ''
+    i = 0
+    while i <= 28:
+        key2_t_xor += chr(ord(key2_t[i]) ^ ord(kilo_challenge[3]))
+        key2_t_xor += chr(ord(key2_t[i+1]) ^ ord(kilo_challenge[2]))
+        key2_t_xor += chr(ord(key2_t[i+2]) ^ ord(kilo_challenge[1]))
+        key2_t_xor += chr(ord(key2_t[i+3]) ^ ord(kilo_challenge[0]))
+        i = i + 4
+    return key2_t_xor
+
+def do_aes_encrypt(key2_t_xor):
+    plaintext = b''
+    for k in range(0,16):
+        plaintext += chr(k)
+    obj = AES.new(key2_t_xor, AES.MODE_ECB)
+    return obj.encrypt(plaintext)
+
+def do_challenge_response(comm):
+    request_kilo = lglaf.make_request(b'KILO', args=[b'CENT', b'\0\0\0\0', b'\0\0\0\0', b'\0\0\0\0'])
+    kilo_header, kilo_response = comm.call(request_kilo)
+    kilo_challenge = kilo_header[8:12]
+    chalstring = ":".join("{:02x}".format(ord(k)) for k in kilo_challenge)
+    _logger.debug("Challenge: %s" %chalstring)
+    key2 = b'qndiakxxuiemdklseqid~a~niq,zjuxl' # if this doesnt work try 'lgowvqnltpvtgogwswqn~n~mtjjjqxro'
+    kilo_response = do_aes_encrypt(key_xoring(key_transform(key2), kilo_challenge))
+    respstring = ":".join("{:02x}".format(ord(m)) for m in kilo_response)
+    _logger.debug("Response: %s" %respstring)
+    request_kilo_metr =  lglaf.make_request(b'KILO', args=[b'METR', b'\0\0\0\0', b'\x02\0\0\0', b'\0\0\0\0'], body=bytes(kilo_response))
+    metr_header, metr_response = comm.call(request_kilo_metr)
+
+def main():
+    args = parser.parse_args()
+    logging.basicConfig(format='%(name)s: %(levelname)s: %(message)s',
+            level=logging.DEBUG if args.debug else logging.INFO)
+
+    comm = lglaf.autodetect_device()
+    with closing(comm):
+        do_challenge_response(comm)
+        lglaf.try_hello(comm)
+
+if __name__ == '__main__':
+    try:
+        main()
+    except OSError as e:
+        # Ignore when stdout is closed in a pipe
+        if e.errno != 32:
+            raise
+


### PR DESCRIPTION
this is based on PR #12 with the following difference:

instead of adding a --unlock option to lglaf.py I use an own executable.
The reason is that within download mode you need to authenticate
only ONCE ( - IF you need to) and afterwards you're able to exec every
other action like partitions.py etc without doing it again (until you reboot
into download mode again ofc).