### PR TITLE
fix: Expected arrow in ls output

### DIFF
--- a/partitions.py
+++ b/partitions.py
@@ -37,6 +37,8 @@ def get_partitions(comm):
     output = output.strip().decode('ascii')
     names = []
     for line in output.strip().split("\n"):
+        if(line.split()[0] == 'total'):
+            continue
         label, arrow, path = line.split()[-3:]
         assert arrow == '->', "Expected arrow in ls output"
         blockdev = path.split('/')[-1]


### PR DESCRIPTION
This will fix the partition table output handing on some firmwares.
Origin post:
https://forum.xda-developers.com/showpost.php?p=74072785&postcount=54