### PR TITLE
Add rawshell switch => Don't prepend anything to shell command

### DIFF
--- a/lglaf.py
+++ b/lglaf.py
@@ -427,7 +427,8 @@ parser = argparse.ArgumentParser(description='LG LAF Download Mode utility')
 parser.add_argument("--skip-hello", action="store_true",
         help="Immediately send commands, skip HELO message")
 parser.add_argument('--rawshell', action="store_true",
-        help="Execute shell commands as-is, needed on recent devices")
+        help="Execute shell commands as-is, needed on recent devices. "
+             "CAUTION: stderr output is not redirected!")
 parser.add_argument("-c", "--command", help='Shell command to execute')
 parser.add_argument("--serial", metavar="PATH", dest="serial_path",
         help="Path to serial device (e.g. COM4).")


### PR DESCRIPTION
**Rawshell cmdline switch**
For more locked-down / recent devices the prepending of **b'sh -c eval\t"$*"</dev/null\t2>&1 -- '** [(Source code)](https://github.com/Lekensteyn/lglaf/blob/master/lglaf.py#L191) will make every command fail.
When providing the switch **--rawshell**, the command is sent as-is.

Fixes Pull requests:
#24 LG Q6: additionnal limitations from Lg ? (Point 2)

Before:
```
Type a shell command to execute or "exit" to leave.
# ls /sbin/lafd
Hello, I am LAF. Nice to meet you. #
```

Now:
```
Type a shell command to execute or "exit" to leave.
# ls -l /sbin/lafd
-rwxr-x--- root     root       496888 1970-01-01 00:00 lafd
#
```