### PR TITLE
Added Docker and Vagrant support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.vagrant
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+LABEL maintainer="David Manouchehri"
+
+RUN useradd -m lglaf
+WORKDIR /home/lglaf
+ENV HOME /home/lglaf
+
+RUN apt-get -y update && \
+	DEBIAN_FRONTEND=noninteractive apt-get -y install git python-pip usbutils udev && \
+	pip install --upgrade pip && \
+	pip install pyusb && \
+	su - lglaf -c "git clone https://github.com/Lekensteyn/lglaf.git" && \
+	cp -v ~/lglaf/rules.d/42-usb-lglaf.rules /etc/udev/rules.d/ && \
+	udevadm control --reload-rules || true && \
+	udevadm trigger
+
+# udev is sadly broken..
+# USER lglaf
+ENV PATH /home/lglaf/lglaf:$PATH
+
+CMD ["/bin/bash"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Author: David Manouchehri
+
+Vagrant.configure("2") do |config|
+	config.vm.box = "bento/ubuntu-16.04"
+
+	# config.vm.synced_folder ".", "/vagrant", disabled: true
+
+	config.vm.provision "docker" do |d|
+		d.build_image '/vagrant/.', args: "-t lglaf"
+		d.run "lglaf",
+			args: "--privileged -it -v '/dev/bus/usb:/dev/bus/usb'"
+	end
+
+	%w(vmware_fusion vmware_workstation vmware_appcatalyst).each do |provider|
+		config.vm.provider provider do |v|
+			# v.vmx["memsize"] = "2048"
+			v.vmx['ethernet0.virtualDev'] = 'vmxnet3'
+			v.vmx["usb.vbluetooth.startConnected"] = "FALSE"
+			v.vmx["usb.present"] = "TRUE"
+			v.vmx["usb_xhci.present"] = "FALSE"
+			v.vmx["usb.generic.autoconnect"] = "FALSE"
+			v.vmx["usb.autoConnect.device0"] = "0x1004:0x633E"
+			v.vmx["usb.autoConnect.device1"] = "0x1004:0x627F"
+			v.vmx["usb.autoConnect.device2"] = "0x1004:0x6298"
+			v.vmx["usb.autoConnect.device3"] = "0x1004:0x633A"
+		end
+	end
+end


### PR DESCRIPTION
Example usage:

```bash
mbp:lglaf dave$ vagrant up
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Cloning VMware VM: 'bento/ubuntu-16.04'. This can take some time...
==> default: Checking if box 'bento/ubuntu-16.04' is up to date...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for the VM to receive an address...
==> default: Waiting for machine to boot. This may take a few minutes...
==> default: Machine booted and ready!
==> default: Configuring network adapters within the VM...
==> default: Waiting for HGFS to become available...
==> default: Enabling and configuring shared folders...
    default: -- /Users/dave/lglaf: /vagrant
==> default: Running provisioner: docker...
    default: Installing Docker onto machine...
==> default: Starting Docker containers...
==> default: -- Container: thawsystems/lglaf
mbp:lglaf dave$ vagrant ssh
vagrant@vagrant:~$ docker attach lglaf
vagrant@vagrant:~$ docker attach lglaf
root@14d9056e4d77:~# lglaf.py
No handlers could be found for logger "LGLAF.py"
LGLAF.py by Peter Wu (https://lekensteyn.nl/lglaf)
Type a shell command to execute or "exit" to leave.
# whoami
root
# id
uid=0(root) gid=0(root) groups=0(root) context=u:r:kernel:s0
```