### PR TITLE
fix wrong part_size calculation (1 sector missing)

### DIFF
--- a/extract-partitions.py
+++ b/extract-partitions.py
@@ -26,7 +26,7 @@ def dump_partitions(comm, disk_fd, outdir, max_size):
     diskinfo = partitions.get_partitions(comm, disk_fd)
     for part in diskinfo.gpt.partitions:
         part_offset = part.first_lba * partitions.BLOCK_SIZE
-        part_size = (part.last_lba - part.first_lba) * partitions.BLOCK_SIZE
+        part_size = (part.last_lba - (part.first_lba - 1)) * partitions.BLOCK_SIZE
         part_name = part.name
         part_label = "/dev/mmcblk0p%i" % part.index
         if max_size and part_size > max_size:

--- a/partitions.py
+++ b/partitions.py
@@ -259,7 +259,7 @@ def main():
             _logger.debug("%s", info)
 
             part_offset = part.first_lba * BLOCK_SIZE
-            part_size = (part.last_lba - part.first_lba) * BLOCK_SIZE
+            part_size = (part.last_lba - (part.first_lba - 1)) * BLOCK_SIZE
 
             _logger.debug("Opened fd %d for disk", disk_fd)
             if args.dump:


### PR DESCRIPTION
IRC excerpt:
[12-20 15:20]  <steadfasterX> i have a partition: end=378879 start=377856
[12-20 15:21]  <steadfasterX> so the calcluation would be 378879-377856
[12-20 15:21]  <steadfasterX> which is 1023
[12-20 15:21]  <steadfasterX> which can never be correct
[12-20 15:22]  <steadfasterX> this is bc in the calculation it will need to include the start (or end) sector itself
[12-20 15:23]  <steadfasterX> when i dump without that +1 i miss exact 512 bytes so 1 sector