### PR TITLE
Fix method 'def detect_serial_path():' on windows 10:

### DIFF
--- a/lglaf.py
+++ b/lglaf.py
@@ -396,7 +396,7 @@ def detect_serial_path():
                 name, value, value_type = winreg.EnumValue(key, i)
                 # match both \Device\LGANDNETDIAG1 and \Device\LGVZANDNETDIAG1
                 name = name.upper()
-                if name.startswith(r'\DEVICE\LG') and (name.endswith('G1') or name.endwith('G2')):
+                if name.startswith(r'\DEVICE\LG') and (name.endswith('G1') or name.endswith('G2')):
                     return value
     except OSError: pass
     return None

--- a/lglaf.py
+++ b/lglaf.py
@@ -396,7 +396,7 @@ def detect_serial_path():
                 name, value, value_type = winreg.EnumValue(key, i)
                 # match both \Device\LGANDNETDIAG1 and \Device\LGVZANDNETDIAG1
                 name = name.upper()
-                if name.startswith(r'\DEVICE\LG') and name.endswith('ANDNETDIAG1'):
+                if name.startswith(r'\DEVICE\LG') and (name.endswith('G1') or name.endwith('G2')):
                     return value
     except OSError: pass
     return None


### PR DESCRIPTION
- changed line 399 to: if name.startswith(r'\DEVICE\LG') and (name.endswith('G1') or name.endswith('G2')):
- this condition prevented the script from finding my lg k10 250ds device that has the name in the registry \Device\LGSIDIAG1