### PR TITLE
Reset usb before connection.

### DIFF
--- a/lglaf.py
+++ b/lglaf.py
@@ -282,6 +282,7 @@ class USBCommunication(Communication):
                 custom_match = self._match_device)
         if self.usbdev is None:
             raise RuntimeError("USB device not found")
+        self.usbdev.reset()
         cfg = usb.util.find_descriptor(self.usbdev,
                 custom_match=self._match_configuration)
         current_cfg = self.usbdev.get_active_configuration()


### PR DESCRIPTION
This is required here for `lglaf` works at all. Otherwise, according to a wireshark capture, the bulk out packet goes out but there are no bulk in package (as it should) for the HELO message. It still fails the same way if the HELO message is skipped.

The problem was also seen on @steadfasterX fork.

After applying this patch the communication is established. Tested on an LG K-100

This is based on https://github.com/Lekensteyn/lglaf/issues/3 Thanks @shinobisoft :) 

Note: I needed to add the `--skip-hello` for the opened shell to return some sensible responses.