### PR TITLE
fix: replace deprecated logger.warn with logger.warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.py[cod]
+__pycache__/
+venv/
+.*.sw?

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2015, 2016 Peter Wu <peter@lekensteyn.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# LGLAF.py
+LGLAF.py is a utility for communication with LG devices in Download Mode. This
+allows you to execute arbitrary shell commands on a LG phone as root.
+
+Contents of this repository:
+
+ - [lglaf.py](lglaf.py) - main script for communication (see below).
+ - [partitions.py](partitions.py) - manage (list / read / write) partitions.
+ - [extract-partitions.py](extract-partitions.py) - Dump all partitions
+   (convenience script that uses partitions.py under the hood). By default the
+   largest partitions (system, cache, cust, userdata) are not dumped though.
+   This can be changed with the `--max-size` option.
+ - [dump-file.py](dump-file.py) - dumps a regular file from device.
+ - [protocol.md](protocol.md) - Protocol documentation.
+ - [lglaf.lua](lglaf.lua) - Wireshark dissector for LG LAF protocol.
+ - [scripts/](scripts/) - Miscellaneous scripts.
+
+## Requirements
+LGLAF.py depends on:
+
+ - Python 2.7 or 3: https://www.python.org/
+ - (Windows) LG driver,
+   [LGMobileDriver\_WHQL\_Ver\_4.2.0.exe](http://oceanhost.eu/wylc5rg7a8ou/LGMobileDriver_WHQL_Ver_4.2.0.exe.htm)
+   (16691672 bytes,
+   sha256sum: d78ae6dfe7d34b9cabb8c4de5c6e734b6fed20b513d0da0183871bd77abba56c),
+   **WARNING**: This file was found via google search, it's not downloaded directly from LG servers
+ - (Linux) PyUSB: https://walac.github.io/pyusb/
+ - Cryptography library: https://cryptography.io/en/latest/
+
+On Linux, you must also install
+[rules.d/42-usb-lglaf.rules](rules.d/42-usb-lglaf.rules) to `/etc/udev/rules.d/`
+in order to give the regular user access to the USB device.
+
+Tested with:
+
+ - LG G3 (D855) on 64-bit Arch Linux (Python 3.5.1, pyusb 1.0.0b2, libusb 1.0.20)
+ - LG G3 (D855) on 32-bit Windows XP (Python 3.4.4, LG drivers).
+ - LG G2 (VS985).
+ - LG G4 (VS986) on Linux (Python 3.5) and Windows.
+ - LG K10 2017 (M250N) on Linux (Both Python 2.7.13 and Python 3.5.3).
+
+## Usage
+This tool provides an interactive shell where you can execute commands in
+Download Mode. To enter this mode:
+
+ 1. Power off the phone.
+ 2. Connect the phone to a computer using a USB cable.
+ 3. Press and hold **Volume up**.
+ 4. Briefly press the power button.
+ 5. Wait for the **Download mode** screen to appear.
+ 6. Release keys. You should now see a **Firmware Update** screen.
+
+Now you can issue commands using the interactive shell:
+
+    (venv)[peter@al lglaf]$ python lglaf.py
+    LGLAF.py by Peter Wu (https://lekensteyn.nl/lglaf)
+    Type a shell command to execute or "exit" to leave.
+    # pwd
+    /
+    # uname -a
+    -: uname: not found
+    # cat /proc/version
+    Linux version 3.4.0-perf-gf95c7ee (lgmobile@LGEARND12B2) (gcc version 4.8 (GCC) ) #1 SMP PREEMPT Tue Aug 18 19:25:04 KST 2015
+    # exit
+
+When commands are piped to stdin (or given via `-c`), the prompt is hidden:
+
+    (venv)[peter@al lglaf]$ echo mount | python lglaf.py
+    rootfs / rootfs rw 0 0
+    tmpfs /dev tmpfs rw,seclabel,nosuid,relatime,size=927232k,nr_inodes=87041,mode=755 0 0
+    devpts /dev/pts devpts rw,seclabel,relatime,mode=600 0 0
+    proc /proc proc rw,relatime 0 0
+    sysfs /sys sysfs rw,seclabel,relatime 0 0
+    selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
+    debugfs /sys/kernel/debug debugfs rw,relatime 0 0
+    /dev/block/platform/msm_sdcc.1/by-name/system /system ext4 ro,seclabel,noatime,data=ordered 0 0
+    /dev/block/platform/msm_sdcc.1/by-name/userdata /data ext4 rw,seclabel,nosuid,nodev,noatime,noauto_da_alloc,resuid=1000,errors=continue,data=ordered 0 0
+    /dev/block/platform/msm_sdcc.1/by-name/persist /persist ext4 ro,seclabel,nosuid,nodev,relatime,data=ordered 0 0
+    /dev/block/platform/msm_sdcc.1/by-name/cache /cache ext4 rw,seclabel,nosuid,nodev,noatime,data=ordered 0 0
+    (venv)[peter@al lglaf]$ python lglaf.py -c date
+    Thu Jan  1 01:30:06 GMT 1970
+    (venv)[peter@al lglaf]$
+
+## Advanced usage
+If you know the [protocol](protocol.md), you can send commands directly. Each
+request has a command, zero to four arguments and possibly a body. The
+`lglaf.py` tool accepts this command:
+
+    ![command] [arguments] [body]
+
+All of these words accept escape sequences such as `\0` (octal escape), `\x00`
+(hex), `\n`, `\r` and `\t`. The command must be exactly four bytes, the
+arguments and body are optional.
+
+Arguments are comma-separated and must either be four-byte sequences (such as
+`\0\1\2\3`) or numbers (such as 0x03020100). If no arguments are given, but a
+body is needed, keep two spaces between the command and argument.
+
+Reboot device (command CTRL, arg1 RSET, no body):
+
+    $ ./lglaf.py  --debug -c '!CTRL RSET'
+    LGLAF.py: DEBUG: Hello done, proceeding with commands
+    LGLAF.py: DEBUG: Header: b'CTRL' b'RSET' b'\0\0\0\0' b'\0\0\0\0' b'\0\0\0\0' b'\0\0\0\0' b'\xc7\xeb\0\0' b'\xbc\xab\xad\xb3'
+
+Execute a shell command (command EXEC, no args, with body):
+
+    $ ./lglaf.py --debug --skip-hello -c '!EXEC  id\0'
+    LGLAF.py: DEBUG: Header: b'EXEC' b'\0\0\0\0' b'\0\0\0\0' b'\0\0\0\0' b'\0\0\0\0' b'/\0\0\0' b'\x8dK\0\0' b'\xba\xa7\xba\xbc'
+    uid=0(root) gid=0(root) context=u:r:toolbox:s0
+
+## License
+See the [LICENSE](LICENSE) file for the license (MIT).

--- a/dump-file.py
+++ b/dump-file.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+#
+# Dumps the contents of a file.
+#
+# Copyright (C) 2016 Peter Wu <peter@lekensteyn.nl>
+# Licensed under the MIT license <http://opensource.org/licenses/MIT>.
+
+from contextlib import closing, contextmanager
+import argparse, logging, os, struct, sys
+import lglaf
+
+_logger = logging.getLogger("dump-file")
+
+def read_uint32(data, offset):
+    return struct.unpack_from('<I', data, offset)[0]
+
+def get_file_size(comm, path):
+    shell_command = b'ls -ld ' + path.encode('utf8') + b'\0'
+    output = comm.call(lglaf.make_request(b'EXEC', body=shell_command))[1]
+    output = output.decode('utf8')
+    if not len(output):
+        raise RuntimeError("Cannot find file %s" % path)
+    # Example output: "-rwxr-x--- root     root       496888 1970-01-01 00:00 lafd"
+    # Accommodate for varying ls output
+    fields = output.split()
+    if len(fields) >= 7:
+        for field in fields[3:]:
+            if field.isdigit():
+                return int(field)
+
+    _logger.debug("ls output: %s", output)
+    raise RuntimeError("Cannot find filesize for path %s" % path)
+
+@contextmanager
+def laf_open_ro(comm, filename):
+    filename = filename.encode('utf8') + b'\0'
+    # Open a single file in readonly mode
+    open_cmd = lglaf.make_request(b'OPEN', body=filename)
+    open_header = comm.call(open_cmd)[0]
+    fd_num = read_uint32(open_header, 4)
+    try:
+        yield fd_num
+    finally:
+        close_cmd = lglaf.make_request(b'CLSE', args=[fd_num])
+        comm.call(close_cmd)
+
+def laf_read(comm, fd_num, offset, size):
+    """Read size bytes at the given block offset."""
+    read_cmd = lglaf.make_request(b'READ', args=[fd_num, offset, size])
+    header, response = comm.call(read_cmd)
+    # Ensure that response fd, offset and length are sane (match the request)
+    assert read_cmd[4:4+12] == header[4:4+12], "Unexpected read response"
+    assert len(response) == size
+    return response
+
+# On Linux, one bulk read returns at most 16 KiB. 32 bytes are part of the first
+# header, so remove one block size (512 bytes) to stay within that margin.
+# This ensures that whenever the USB communication gets out of sync, it will
+# always start with a message header, making recovery easier.
+MAX_BLOCK_SIZE = (16 * 1024 - 512) // 512
+BLOCK_SIZE = 512
+
+def dump_file(comm, file_fd, output_file, size, offset=0):
+    with open_local_writable(output_file) as f:
+        while offset < size:
+            chunksize = min(size - offset, BLOCK_SIZE * MAX_BLOCK_SIZE)
+            data = laf_read(comm, file_fd, offset // BLOCK_SIZE, chunksize)
+            f.write(data)
+            offset += chunksize
+        _logger.info("Wrote %d bytes to %s", size, output_file)
+
+def open_local_writable(path):
+    if path == '-':
+        try: return sys.stdout.buffer
+        except: return sys.stdout
+    else:
+        return open(path, "wb")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+parser.add_argument("--offset", type=int, default=0,
+        help="Start reading the file from an offset")
+parser.add_argument("--size", type=int,
+        help="Override file size (useful for files in /proc)")
+parser.add_argument("file", help="File path on the device")
+parser.add_argument("output_file",
+        help="Local output file (use '-' for stdout)")
+
+def main():
+    args = parser.parse_args()
+    logging.basicConfig(format='%(asctime)s %(name)s: %(levelname)s: %(message)s',
+            level=logging.DEBUG if args.debug else logging.INFO)
+
+    comm = lglaf.autodetect_device()
+    with closing(comm):
+        lglaf.try_hello(comm)
+
+        # Be careful: a too large read size will result in a hang while LAF
+        # tries to read more data, requiring a reset.
+        if args.size:
+            offset = args.offset
+            size = args.size
+        else:
+            offset = args.offset
+            size = get_file_size(comm, args.file)
+            if offset > size:
+                _logger.warning("Offset %d is larger than the detected size %d",
+                        offset, size)
+            size -= offset
+        if size > 0:
+            _logger.debug("File size is %d", size)
+            with laf_open_ro(comm, args.file) as file_fd:
+                _logger.debug("Opened fd %d for file %s", file_fd, args.file)
+                dump_file(comm, file_fd, args.output_file, size, offset)
+        else:
+            _logger.warning("Not a file or zero size, not writing file")
+
+if __name__ == '__main__':
+    try:
+        main()
+    except OSError as e:
+        # Ignore when stdout is closed in a pipe
+        if e.errno != 32:
+            raise

--- a/extract-partitions.py
+++ b/extract-partitions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Dump partitions to file.
+#
+# Copyright (C) 2015 Peter Wu <peter@lekensteyn.nl>
+# Licensed under the MIT license <http://opensource.org/licenses/MIT>.
+
+from contextlib import closing
+import argparse, logging, os, struct
+import lglaf, partitions
+
+_logger = logging.getLogger("extract-partitions")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-d", "--outdir", default=".",
+        help="Output directory for disk images.")
+# Do not dump partitions larger than this size
+# (userdata 11728 MiB, system 2064 MiB, cache 608 MiB, cust 256 MiB)
+parser.add_argument("--max-size", metavar="kbytes", type=int, default=65535,
+        help="Maximum partition size to dump (in KiB) or 0 to dump all (default %(default)d)")
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+parser.add_argument("--skip-hello", action="store_true",
+        help="Immediately send commands, skip HELO message")
+
+def dump_partitions(comm, disk_fd, outdir, max_size):
+    diskinfo = partitions.get_partitions(comm, disk_fd)
+    for part in diskinfo.gpt.partitions:
+        part_offset = part.first_lba * partitions.BLOCK_SIZE
+        part_size = (part.last_lba - (part.first_lba - 1)) * partitions.BLOCK_SIZE
+        part_name = part.name
+        part_label = "/dev/mmcblk0p%i" % part.index
+        if max_size and part_size > max_size:
+            _logger.info("Ignoring large partition %s (%s) of size %dK",
+                    part_label, part_name, part_size / 1024)
+            continue
+        out_path = os.path.join(outdir, "%s.bin" % part_name)
+        try:
+            current_size = os.path.getsize(out_path)
+            if current_size > part_size:
+                _logger.warning("%s: unexpected size %dK, larger than %dK",
+                        out_path, current_size / 1024, part_size / 1024)
+                continue
+            elif current_size == part_size:
+                _logger.info("Skipping partition %s (%s), already found at %s",
+                        part_label, part_name, out_path)
+                continue
+        except OSError: pass
+        _logger.info("Dumping partition %s (%s) to %s (%d bytes)",
+                part_label, part_name, out_path, part_size)
+        partitions.dump_partition(comm, disk_fd, out_path, part_offset, part_size)
+
+def main():
+    args = parser.parse_args()
+    logging.basicConfig(format='%(asctime)s %(name)s: %(levelname)s: %(message)s',
+            level=logging.DEBUG if args.debug else logging.INFO)
+
+    try: os.makedirs(args.outdir)
+    except OSError: pass
+
+    comm = lglaf.autodetect_device()
+    with closing(comm):
+        if not args.skip_hello:
+            lglaf.try_hello(comm)
+
+        with partitions.laf_open_disk(comm) as disk_fd:
+            _logger.debug("Opened fd %d for disk", disk_fd)
+            dump_partitions(comm, disk_fd, args.outdir, args.max_size * 1024)
+
+if __name__ == '__main__':
+    main()

--- a/gpt.py
+++ b/gpt.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python
+# coding: utf-8
+# vim:et:sta:sts=2:sw=2:ts=2:tw=0:
+"""
+Source: https://github.com/jrd/pyreadpartitions
+
+Read MBR (msdos) and GPT partitions for a disk on UNIX.
+Does not rely on any os tools or library.
+
+Exemple:
+  import pyreadpartitions as pyrp
+  fp = open('/dev/sda', 'rb')
+  info = pyrp.get_disk_partitions_info(fp)
+  print(info.mbr)
+  print(info.gpt)
+  pyrp.show_disk_partitions_info(info)
+  fp.close()
+  with open('/dev/sda', 'rb') as fp:
+    pyrp.show_disk_partitions_info(fp)
+
+"""
+from __future__ import print_function, unicode_literals, division, absolute_import
+
+__copyright__ = 'Copyright 2013-2014, Salix OS'
+__author__ = 'Cyrille Pontvieux <jrd@salixos.org>'
+__credits__ = ['Cyrille Pontvieux']
+__email__ = 'jrd@salixos.org'
+__license__ = 'MIT'
+__version__ = '1.0.0'
+
+from collections import namedtuple
+import struct
+import sys
+import uuid
+#from fcntl import ioctl
+
+# http://en.wikipedia.org/wiki/Master_boot_record#Sector_layout
+MBR_FORMAT = [
+  (b'446x', '_'),  # boot code
+  (b'16s', 'partition1'),
+  (b'16s', 'partition2'),
+  (b'16s', 'partition3'),
+  (b'16s', 'partition4'),
+  (b'2s', 'signature'),
+]
+# http://en.wikipedia.org/wiki/Master_boot_record#Partition_table_entries
+MBR_PARTITION_FORMAT = [
+  (b'B', 'status'),  # > 0x80 => active
+  (b'3p', 'chs_first'),  # 8*h + 2*c + 6*s + 8*c
+  (b'B', 'type'),
+  (b'3p', 'chs_last'),  # 8*h + 2*c + 6*s + 8*c
+  (b'L', 'lba'),
+  (b'L', 'sectors'),
+]
+# http://en.wikipedia.org/wiki/Partition_type#List_of_partition_IDs
+MBR_PARTITION_TYPE = {
+  0x00: 'Empty',
+  0x01: 'FAT12',
+  0x04: 'FAT16 16-32MB',
+  0x05: 'Extended, CHS',
+  0x06: 'FAT16 32MB-2GB',
+  0x07: 'NTFS',
+  0x0B: 'FAT32',
+  0x0C: 'FAT32X',
+  0x0E: 'FAT16X',
+  0x0F: 'Extended, LBA',
+  0x11: 'Hidden FAT12',
+  0x14: 'Hidden FAT16,16-32MB',
+  0x15: 'Hidden Extended, CHS',
+  0x16: 'Hidden FAT16,32MB-2GB',
+  0x17: 'Hidden NTFS',
+  0x1B: 'Hidden FAT32',
+  0x1C: 'Hidden FAT32X',
+  0x1E: 'Hidden FAT16X',
+  0x1F: 'Hidden Extended, LBA',
+  0x27: 'Windows recovery environment',
+  0x39: 'Plan 9',
+  0x3C: 'PartitionMagic recovery partition',
+  0x42: 'Windows dynamic extended partition marker',
+  0x44: 'GoBack partition',
+  0x63: 'Unix System V',
+  0x64: 'PC-ARMOUR protected partition',
+  0x81: 'Minix',
+  0x82: 'Linux Swap',
+  0x83: 'Linux',
+  0x84: 'Hibernation',
+  0x85: 'Linux Extended',
+  0x86: 'Fault-tolerant FAT16B volume set',
+  0x87: 'Fault-tolerant NTFS volume set',
+  0x88: 'Linux plaintext',
+  0x8E: 'Linux LVM',
+  0x93: 'Hidden Linux',
+  0x9F: 'BSD/OS',
+  0xA0: 'Hibernation',
+  0xA1: 'Hibernation',
+  0xA5: 'FreeBSD',
+  0xA6: 'OpenBSD',
+  0xA8: 'Mac OS X',
+  0xA9: 'NetBSD',
+  0xAB: 'Mac OS X Boot',
+  0xAF: 'Mac OS X HFS',
+  0xBE: 'Solaris 8 boot partition',
+  0xBF: 'Solaris x86',
+  0xE8: 'Linux Unified Key Setup',
+  0xEB: 'BFS',
+  0xEE: 'EFI GPT protective MBR',
+  0xEF: 'EFI system partition',
+  0xFA: 'Bochs x86 emulator',
+  0xFB: 'VMware File System',
+  0xFC: 'VMware Swap',
+  0xFD: 'Linux RAID',
+}
+MBR_EXTENDED_TYPE = [0x05, 0x0F, 0x15, 0x1F, 0x85]
+# http://en.wikipedia.org/wiki/Extended_boot_record#Structures
+EBR_FORMAT = [
+  (b'446x', '_'),
+  (b'16s', 'partition'),  # lba = offset from ebr, sectors = size of partition
+  (b'16s', 'next_ebr'),  # lba = offset from extended partition, sectors = next EBR + next Partition size
+  (b'16x', '_'),
+  (b'16x', '_'),
+  (b'2s', 'signature'),
+]
+# http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_.28LBA_1.29
+GPT_HEADER_FORMAT = [
+  (b'8s', 'signature'),
+  (b'H', 'revision_minor'),
+  (b'H', 'revision_major'),
+  (b'L', 'header_size'),
+  (b'L', 'crc32'),
+  (b'4x', '_'),
+  (b'Q', 'current_lba'),
+  (b'Q', 'backup_lba'),
+  (b'Q', 'first_usable_lba'),
+  (b'Q', 'last_usable_lba'),
+  (b'16s', 'disk_guid'),
+  (b'Q', 'part_entry_start_lba'),
+  (b'L', 'num_part_entries'),
+  (b'L', 'part_entry_size'),
+  (b'L', 'crc32_part_array'),
+]
+# http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_entries_.28LBA_2.E2.80.9333.29
+GPT_PARTITION_FORMAT = [
+  (b'16s', 'guid'),
+  (b'16s', 'uid'),
+  (b'Q', 'first_lba'),
+  (b'Q', 'last_lba'),
+  (b'Q', 'flags'),
+  (b'72s', 'name'),
+]
+# http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+GPT_GUID = {
+  '024DEE41-33E7-11D3-9D69-0008C781F39F': 'MBR partition scheme',
+  'C12A7328-F81F-11D2-BA4B-00A0C93EC93B': 'EFI System partition',
+  '21686148-6449-6E6F-744E-656564454649': 'BIOS Boot partition',
+  'D3BFE2DE-3DAF-11DF-BA40-E3A556D89593': 'Intel Fast Flash (iFFS) partition (for Intel Rapid Start technology)',
+  'F4019732-066E-4E12-8273-346C5641494F': 'Sony boot partition',
+  'BFBFAFE7-A34F-448A-9A5B-6213EB736C22': 'Lenovo boot partition',
+  'E3C9E316-0B5C-4DB8-817D-F92DF00215AE': 'Microsoft Reserved Partition (MSR)',
+  'EBD0A0A2-B9E5-4433-87C0-68B6B72699C7': 'Basic data partition',
+  '5808C8AA-7E8F-42E0-85D2-E1E90434CFB3': 'Logical Disk Manager (LDM) metadata partition',
+  'AF9B60A0-1431-4F62-BC68-3311714A69AD': 'Logical Disk Manager data partition',
+  'DE94BBA4-06D1-4D40-A16A-BFD50179D6AC': 'Windows Recovery Environment',
+  '37AFFC90-EF7D-4E96-91C3-2D7AE055B174': 'IBM General Parallel File System (GPFS) partition',
+  '75894C1E-3AEB-11D3-B7C1-7B03A0000000': 'Data partition',
+  'E2A1E728-32E3-11D6-A682-7B03A0000000': 'Service Partition',
+  '0FC63DAF-8483-4772-8E79-3D69D8477DE4': 'Linux filesystem data',
+  'A19D880F-05FC-4D3B-A006-743F0F84911E': 'RAID partition',
+  '0657FD6D-A4AB-43C4-84E5-0933C84B4F4F': 'Swap partition',
+  'E6D6D379-F507-44C2-A23C-238F2A3DF928': 'Logical Volume Manager (LVM) partition',
+  '933AC7E1-2EB4-4F13-B844-0E14E2AEF915': '/home partition',
+  '3B8F8425-20E0-4F3B-907F-1A25A76F98E8': '/srv partition',
+  '7FFEC5C9-2D00-49B7-8941-3EA10A5586B7': 'Plain dm-crypt partition',
+  'CA7D7CCB-63ED-4C53-861C-1742536059CC': 'LUKS partition',
+  '8DA63339-0007-60C0-C436-083AC8230908': 'Reserved',
+  '83BD6B9D-7F41-11DC-BE0B-001560B84F0F': 'Boot partition',
+  '516E7CB4-6ECF-11D6-8FF8-00022D09712B': 'Data partition',
+  '516E7CB5-6ECF-11D6-8FF8-00022D09712B': 'Swap partition',
+  '516E7CB6-6ECF-11D6-8FF8-00022D09712B': 'Unix File System (UFS) partition',
+  '516E7CB8-6ECF-11D6-8FF8-00022D09712B': 'Vinum volume manager partition',
+  '516E7CBA-6ECF-11D6-8FF8-00022D09712B': 'ZFS partition',
+  '48465300-0000-11AA-AA11-00306543ECAC': 'Hierarchical File System Plus (HFS+) partition',
+  '55465300-0000-11AA-AA11-00306543ECAC': 'Apple UFS',
+  '6A898CC3-1DD2-11B2-99A6-080020736631': 'ZFS',
+  '52414944-0000-11AA-AA11-00306543ECAC': 'Apple RAID partition',
+  '52414944-5F4F-11AA-AA11-00306543ECAC': 'Apple RAID partition, offline',
+  '426F6F74-0000-11AA-AA11-00306543ECAC': 'Apple Boot partition',
+  '4C616265-6C00-11AA-AA11-00306543ECAC': 'Apple Label',
+  '5265636F-7665-11AA-AA11-00306543ECAC': 'Apple TV Recovery partition',
+  '53746F72-6167-11AA-AA11-00306543ECAC': 'Apple Core Storage (i.e. Lion FileVault) partition',
+  '6A82CB45-1DD2-11B2-99A6-080020736631': 'Boot partition',
+  '6A85CF4D-1DD2-11B2-99A6-080020736631': 'Root partition',
+  '6A87C46F-1DD2-11B2-99A6-080020736631': 'Swap partition',
+  '6A8B642B-1DD2-11B2-99A6-080020736631': 'Backup partition',
+  '6A898CC3-1DD2-11B2-99A6-080020736631': '/usr partition',
+  '6A8EF2E9-1DD2-11B2-99A6-080020736631': '/var partition',
+  '6A90BA39-1DD2-11B2-99A6-080020736631': '/home partition',
+  '6A9283A5-1DD2-11B2-99A6-080020736631': 'Alternate sector',
+  '6A945A3B-1DD2-11B2-99A6-080020736631': 'Reserved partition',
+  '6A9630D1-1DD2-11B2-99A6-080020736631': 'Reserved partition',
+  '6A980767-1DD2-11B2-99A6-080020736631': 'Reserved partition',
+  '6A96237F-1DD2-11B2-99A6-080020736631': 'Reserved partition',
+  '6A8D2AC7-1DD2-11B2-99A6-080020736631': 'Reserved partition',
+  '49F48D32-B10E-11DC-B99B-0019D1879648': 'Swap partition',
+  '49F48D5A-B10E-11DC-B99B-0019D1879648': 'FFS partition',
+  '49F48D82-B10E-11DC-B99B-0019D1879648': 'LFS partition',
+  '49F48DAA-B10E-11DC-B99B-0019D1879648': 'RAID partition',
+  '2DB519C4-B10F-11DC-B99B-0019D1879648': 'Concatenated partition',
+  '2DB519EC-B10F-11DC-B99B-0019D1879648': 'Encrypted partition',
+  'FE3A2A5D-4F32-41A7-B725-ACCC3285A309': 'ChromeOS kernel',
+  '3CB8E202-3B7E-47DD-8A3C-7FF2A13CFCEC': 'ChromeOS rootfs',
+  '2E0A753D-9E48-43B0-8337-B15192CB1B5E': 'ChromeOS future use',
+  '42465331-3BA3-10F1-802A-4861696B7521': 'Haiku BFS',
+  '85D5E45E-237C-11E1-B4B3-E89A8F7FC3A7': 'Boot partition',
+  '85D5E45A-237C-11E1-B4B3-E89A8F7FC3A7': 'Data partition',
+  '85D5E45B-237C-11E1-B4B3-E89A8F7FC3A7': 'Swap partition',
+  '0394EF8B-237E-11E1-B4B3-E89A8F7FC3A7': 'Unix File System (UFS) partition',
+  '85D5E45C-237C-11E1-B4B3-E89A8F7FC3A7': 'Vinum volume manager partition',
+  '85D5E45D-237C-11E1-B4B3-E89A8F7FC3A7': 'ZFS partition',
+  'BFBFAFE7-A34F-448A-9A5B-6213EB736C22': 'Ceph Journal',
+  '45B0969E-9B03-4F30-B4C6-5EC00CEFF106': 'Ceph dm-crypt Encrypted Journal',
+  '4FBD7E29-9D25-41B8-AFD0-062C0CEFF05D': 'Ceph OSD',
+  '4FBD7E29-9D25-41B8-AFD0-5EC00CEFF05D': 'Ceph dm-crypt OSD',
+  '89C57F98-2FE5-4DC0-89C1-F3AD0CEFF2BE': 'Ceph disk in creation',
+  '89C57F98-2FE5-4DC0-89C1-5EC00CEFF2BE': 'Ceph dm-crypt disk in creation',
+}
+
+
+def make_fmt(name, fmt, extras=[]):
+  packfmt = b'<' + b''.join(t for t, n in fmt)
+  tupletype = namedtuple(name, [n for t, n in fmt if n != '_'] + extras)
+  return (packfmt, tupletype)
+
+
+class MBRError(Exception):
+  pass
+
+
+class MBRMissing(MBRError):
+  pass
+
+
+class GPTError(Exception):
+  pass
+
+
+class GPTMissing(GPTError):
+  pass
+
+
+def read_mbr_header(fp):
+  fmt, MBRHeader = make_fmt('MBRHeader', MBR_FORMAT)
+  data = fp.read(struct.calcsize(fmt))
+  header = MBRHeader._make(struct.unpack(fmt, data))
+  if header.signature != b'\x55\xAA':
+    raise MBRMissing('Bad MBR signature')
+  return header
+
+
+def read_mbr_partitions(fp, header):
+  def read_mbr_partition(partstr, num):
+    fmt, MBRPartition = make_fmt('MBRPartition', MBR_PARTITION_FORMAT, extras=['index', 'active', 'type_str'])
+    part = MBRPartition._make(struct.unpack(fmt, partstr) + (num, False, ''))
+    if part.type:
+      ptype = 'Unknown'
+      if part.type in MBR_PARTITION_TYPE:
+        ptype = MBR_PARTITION_TYPE[part.type]
+      part = part._replace(active=part.status >= 0x80, type_str=ptype)
+      return part
+
+  def read_ebr_partition(fp, extended_lba, lba, num):
+    fp.seek((extended_lba + lba) * 512)  # lba size is fixed to 512 for MBR
+    fmt, EBR = make_fmt('EBR', EBR_FORMAT)
+    data = fp.read(struct.calcsize(fmt))
+    ebr = EBR._make(struct.unpack(fmt, data))
+    if ebr.signature != b'\x55\xAA':
+      raise MBRError('Bad EBR signature')
+    parts = [read_mbr_partition(ebr.partition, num)]
+    if ebr.next_ebr != 16 * b'\x00':
+      part_next_ebr = read_mbr_partition(ebr.next_ebr, 0)
+      next_lba = part_next_ebr.lba
+      parts.extend(read_ebr_partition(fp, extended_lba, next_lba, num + 1))
+    return parts
+  parts = []
+  for i in range(1, 4):
+    part = read_mbr_partition(getattr(header, 'partition{0}'.format(i)), i)
+    if part:
+      parts.append(part)
+  extendpart = None
+  for part in parts:
+    if part.type in MBR_EXTENDED_TYPE:
+      extendpart = part
+      break
+  if extendpart:
+    parts.extend(read_ebr_partition(fp, extendpart.lba, 0, 5))
+  return parts
+
+
+def read_gpt_header(fp, lba_size=512):
+  try:
+    # skip MBR (if any)
+    fp.seek(1 * lba_size)
+  except IOError as e:
+    raise GPTError(e)
+  fmt, GPTHeader = make_fmt('GPTHeader', GPT_HEADER_FORMAT)
+  data = fp.read(struct.calcsize(fmt))
+  header = GPTHeader._make(struct.unpack(fmt, data))
+  if header.signature != b'EFI PART':
+    raise GPTMissing('Bad GPT signature')
+  revision = header.revision_major + (header.revision_minor / 10)
+  if revision < 1.0:
+    raise GPTError('Bad GPT revision: {0}.{1}'.format(header.revision_major, header.revision_minor))
+  if header.header_size < 92:
+    raise GPTError('Bad GPT header size: {0}'.format(header.header_size))
+  header = header._replace(
+    disk_guid=str(uuid.UUID(bytes_le=header.disk_guid)).upper(),
+  )
+  return header
+
+
+def read_gpt_partitions(fp, header, lba_size=512):
+  fp.seek(header.part_entry_start_lba * lba_size)
+  fmt, GPTPartition = make_fmt('GPTPartition', GPT_PARTITION_FORMAT, extras=['index', 'type'])
+  parts = []
+  for i in range(header.num_part_entries):
+    data = fp.read(header.part_entry_size)
+    if len(data) < struct.calcsize(fmt):
+      raise GPTError('Short GPT partition entry #{0}'.format(i + 1))
+    part = GPTPartition._make(struct.unpack(fmt, data) + (i + 1, ''))
+    if part.guid == 16 * b'\x00':
+      continue
+    guid = str(uuid.UUID(bytes_le=part.guid)).upper()
+    ptype = 'Unknown'
+    if guid in GPT_GUID:
+      ptype = GPT_GUID[guid]
+    part = part._replace(
+      guid=guid,
+      uid=str(uuid.UUID(bytes_le=part.uid)).upper(),
+      # cut on C-style string termination; otherwise you'll see a long row of NILs for most names
+      name=part.name.decode('utf-16').split(u'\0', 1)[0],
+      type=ptype,
+    )
+    parts.append(part)
+  return parts
+
+
+class DiskException(Exception):
+  pass
+
+
+def check_disk_file(disk):
+  try:
+    disk.tell()
+  except:
+    raise DiskException('Please provide a file pointer (sys.stding or result of open function) as first argument, pointing to an existing disk such as /dev/sda.')
+
+
+def get_mbr_info(disk):
+  check_disk_file(disk)
+  disk.seek(0)
+  try:
+    mbrheader = read_mbr_header(disk)
+    partitions = read_mbr_partitions(disk, mbrheader)
+    return namedtuple('MBRInfo', 'lba_size, partitions')(512, partitions)
+  except MBRMissing:
+    return None
+  except MBRError:
+    return None
+
+
+def get_gpt_info(disk):
+  check_disk_file(disk)
+  disk.seek(0)
+  info = {
+    'lba_size': None,
+    'revision_minor': None,
+    'revision_major': None,
+    'crc32': None,
+    'current_lba': None,
+    'backup_lba': None,
+    'first_usable_lba': None,
+    'last_usable_lba': None,
+    'disk_guid': None,
+    'part_entry_start_lba': None,
+    'num_part_entries': None,
+    'part_entry_size': None,
+    'crc32_part_array': None,
+    'partitions': [],
+  }
+  # EDIT by tuxuser: we are only working with datachunks, not real block devices
+  # Using hardcoded LBA size for usage by LGLAF
+  #try:
+  #  blocksize = struct.unpack('i', ioctl(disk.fileno(), 4608 | 104, struct.pack('i', -1)))[0]
+  #except:
+  #  blocksize = 512
+  blocksize = 512
+  try:
+    info['lba_size'] = blocksize
+    gptheader = read_gpt_header(disk, lba_size=blocksize)
+    for key in [k for k in info.keys() if k not in ('lba_size', 'partitions')]:
+      info[key] = getattr(gptheader, key)
+    info['partitions'] = read_gpt_partitions(disk, gptheader, lba_size=blocksize)
+    return namedtuple('GPTInfo', info.keys())(**info)
+  except GPTMissing:
+    return None
+  except GPTError:
+    return None
+
+
+def get_disk_partitions_info(disk):
+  check_disk_file(disk)
+  return namedtuple('DiskInfo', 'mbr, gpt')(get_mbr_info(disk), get_gpt_info(disk))
+
+def show_disk_partitions_info(diskOrInfo):
+  fileUsed = None
+  if hasattr(diskOrInfo, 'read'):
+    info = get_disk_partitions_info(diskOrInfo)
+  else:
+    info = diskOrInfo
+
+  if info.mbr:
+    mbr = info.mbr
+    print('MBR Header')
+    print('LBA size (sector size): {0}', mbr.lba_size)
+    print('Number of MBR partitions: {0}'.format(len(mbr.partitions)))
+    print('#  Active From(#s)   Size(#s)   Code Type')
+    for part in mbr.partitions:
+      print('{n: <2} {boot: ^6} {from_s: <10} {size_s: <10} {code: ^4X} {type}'.format(n=part.index, boot='*' if part.active else '_', from_s=part.lba, size_s=part.sectors, code=part.type, type=part.type_str))
+  else:
+    print('No MBR')
+  print('---')
+  if info.gpt:
+    gpt = info.gpt
+    print('GPT Header')
+    print('Disk GUID: {0}'.format(gpt.disk_guid))
+    print('LBA size (sector size): {0}'.format(gpt.lba_size))
+    print('GPT First LBA: {0}'.format(gpt.current_lba))
+    print('GPT Last  LBA: {0}'.format(gpt.backup_lba))
+    print('Number of GPT partitions: {0}'.format(len(gpt.partitions)))
+    print('#   Flags From(#s)   To(#s)     GUID/UID                             Type/Name')
+    for part in gpt.partitions:
+      print(('{n: <3} {flags: ^5} {from_s: <10} {to_s: <10} {guid} {type}\n' + ' ' * 32 + '{uid} {name}').format(n=part.index, flags=part.flags, from_s=part.first_lba, to_s=part.last_lba, guid=part.guid, type=part.type, uid=part.uid, name=part.name))
+  else:
+    print('No GPT')
+  print('---')
+  if fileUsed:
+    fileUsed.close()
+
+
+if __name__ == '__main__':
+  fp = sys.stdin
+  if len(sys.argv) > 1:
+    fp = open(sys.argv[1])
+  try:
+    show_disk_partitions_info(fp)
+  except DiskException as e:
+    print(e, file=sys.stderr)
+  if fp != sys.stdin:
+    fp.close()

--- a/info/lsusb-d805.txt
+++ b/info/lsusb-d805.txt
@@ -1,0 +1,137 @@
+Bus 001 Device 009: ID 1004:61f1 LG Electronics, Inc. 
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.00
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 ?
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0        64
+  idVendor           0x1004 LG Electronics, Inc.
+  idProduct          0x61f1 
+  bcdDevice            2.32
+  iManufacturer           2 LG Electronics Inc.
+  iProduct                3 LGE Android Phone
+  iSerial                 4 0700a65d19860a02
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength           98
+    bNumInterfaces          3
+    bConfigurationValue     1
+    iConfiguration          0 
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              500mA
+    Interface Association:
+      bLength                 8
+      bDescriptorType        11
+      bFirstInterface         0
+      bInterfaceCount         2
+      bFunctionClass          2 Communications
+      bFunctionSubClass       2 Abstract (modem)
+      bFunctionProtocol       1 AT-commands (v.25ter)
+      iFunction               8 CDC Serial
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass         2 Communications
+      bInterfaceSubClass      2 Abstract (modem)
+      bInterfaceProtocol      1 AT-commands (v.25ter)
+      iInterface              6 CDC Abstract Control Model (ACM)
+      CDC Header:
+        bcdCDC               1.10
+      CDC Call Management:
+        bmCapabilities       0x00
+        bDataInterface          1
+      CDC ACM:
+        bmCapabilities       0x02
+          line coding and serial state
+      CDC Union:
+        bMasterInterface        0
+        bSlaveInterface         1 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               9
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass        10 CDC Data
+      bInterfaceSubClass      0 Unused
+      bInterfaceProtocol      0 
+      iInterface              7 CDC ACM Data
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x01  EP 1 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass    255 Vendor Specific Subclass
+      bInterfaceProtocol    255 Vendor Specific Protocol
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+Device Qualifier (for other device speed):
+  bLength                10
+  bDescriptorType         6
+  bcdUSB               2.00
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 ?
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0        64
+  bNumConfigurations      1
+Device Status:     0x0000
+  (Bus Powered)

--- a/info/lsusb-d852.txt
+++ b/info/lsusb-d852.txt
@@ -1,0 +1,140 @@
+
+Bus 001 Device 064: ID 1004:633a LG Electronics, Inc. 
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.10
+  bDeviceClass          239 Miscellaneous Device
+  bDeviceSubClass         2 ?
+  bDeviceProtocol         1 Interface Association
+  bMaxPacketSize0        64
+  idVendor           0x1004 LG Electronics, Inc.
+  idProduct          0x633a 
+  bcdDevice            2.32
+  iManufacturer           1 LG Electronics Inc.
+  iProduct                2 LGE Android Phone
+  iSerial                 3 LGD852XXXXXXXX
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength           98
+    bNumInterfaces          3
+    bConfigurationValue     1
+    iConfiguration          0 
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              500mA
+    Interface Association:
+      bLength                 8
+      bDescriptorType        11
+      bFirstInterface         0
+      bInterfaceCount         2
+      bFunctionClass          2 Communications
+      bFunctionSubClass       2 Abstract (modem)
+      bFunctionProtocol       1 AT-commands (v.25ter)
+      iFunction               7 CDC Serial
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass         2 Communications
+      bInterfaceSubClass      2 Abstract (modem)
+      bInterfaceProtocol      1 AT-commands (v.25ter)
+      iInterface              5 CDC Abstract Control Model (ACM)
+      CDC Header:
+        bcdCDC               1.10
+      CDC Call Management:
+        bmCapabilities       0x00
+        bDataInterface          1
+      CDC ACM:
+        bmCapabilities       0x02
+          line coding and serial state
+      CDC Union:
+        bMasterInterface        0
+        bSlaveInterface         1 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               9
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass        10 CDC Data
+      bInterfaceSubClass      0 Unused
+      bInterfaceProtocol      0 
+      iInterface              6 CDC ACM Data
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x01  EP 1 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass    255 Vendor Specific Subclass
+      bInterfaceProtocol    255 Vendor Specific Protocol
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+Binary Object Store Descriptor:
+  bLength                 5
+  bDescriptorType        15
+  wTotalLength           12
+  bNumDeviceCaps          1
+  USB 2.0 Extension Device Capability:
+    bLength                 7
+    bDescriptorType        16
+    bDevCapabilityType      2
+    bmAttributes   0x00000000
+      (Missing must-be-set LPM bit!)
+Device Status:     0x0000
+  (Bus Powered)

--- a/info/lsusb-d855.txt
+++ b/info/lsusb-d855.txt
@@ -1,0 +1,193 @@
+Bus 002 Device 013: ID 1004:633e LG Electronics, Inc. G2 Android Phone [MTP mode]
+Device Descriptor:
+  bLength                18
+  bDescriptorType         1
+  bcdUSB               2.10
+  bDeviceClass            0 
+  bDeviceSubClass         0 
+  bDeviceProtocol         0 
+  bMaxPacketSize0        64
+  idVendor           0x1004 LG Electronics, Inc.
+  idProduct          0x633e G2 Android Phone [MTP mode]
+  bcdDevice            2.32
+  iManufacturer           1 LG Electronics Inc.
+  iProduct                2 LGE Android Phone
+  iSerial                 3 LGD855xxxxxxxx
+  bNumConfigurations      1
+  Configuration Descriptor:
+    bLength                 9
+    bDescriptorType         2
+    wTotalLength          128
+    bNumInterfaces          4
+    bConfigurationValue     1
+    iConfiguration          0 
+    bmAttributes         0x80
+      (Bus Powered)
+    MaxPower              500mA
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        0
+      bAlternateSetting       0
+      bNumEndpoints           3
+      bInterfaceClass         6 Imaging
+      bInterfaceSubClass      1 Still Image Capture
+      bInterfaceProtocol      1 Picture Transfer Protocol (PIMA 15470)
+      iInterface              5 MTP
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x81  EP 1 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x01  EP 1 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x82  EP 2 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x001c  1x 28 bytes
+        bInterval               6
+    Interface Association:
+      bLength                 8
+      bDescriptorType        11
+      bFirstInterface         1
+      bInterfaceCount         2
+      bFunctionClass          2 Communications
+      bFunctionSubClass       2 Abstract (modem)
+      bFunctionProtocol       1 AT-commands (v.25ter)
+      iFunction               8 CDC Serial
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        1
+      bAlternateSetting       0
+      bNumEndpoints           1
+      bInterfaceClass         2 Communications
+      bInterfaceSubClass      2 Abstract (modem)
+      bInterfaceProtocol      1 AT-commands (v.25ter)
+      iInterface              6 CDC Abstract Control Model (ACM)
+      CDC Header:
+        bcdCDC               1.10
+      CDC Call Management:
+        bmCapabilities       0x00
+        bDataInterface          2
+      CDC ACM:
+        bmCapabilities       0x02
+          line coding and serial state
+      CDC Union:
+        bMasterInterface        1
+        bSlaveInterface         2 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x84  EP 4 IN
+        bmAttributes            3
+          Transfer Type            Interrupt
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0040  1x 64 bytes
+        bInterval               9
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        2
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass        10 CDC Data
+      bInterfaceSubClass      0 
+      bInterfaceProtocol      0 
+      iInterface              7 CDC ACM Data
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x83  EP 3 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x02  EP 2 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+    Interface Descriptor:
+      bLength                 9
+      bDescriptorType         4
+      bInterfaceNumber        3
+      bAlternateSetting       0
+      bNumEndpoints           2
+      bInterfaceClass       255 Vendor Specific Class
+      bInterfaceSubClass    255 Vendor Specific Subclass
+      bInterfaceProtocol    255 Vendor Specific Protocol
+      iInterface              0 
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x85  EP 5 IN
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+      Endpoint Descriptor:
+        bLength                 7
+        bDescriptorType         5
+        bEndpointAddress     0x03  EP 3 OUT
+        bmAttributes            2
+          Transfer Type            Bulk
+          Synch Type               None
+          Usage Type               Data
+        wMaxPacketSize     0x0200  1x 512 bytes
+        bInterval               0
+Binary Object Store Descriptor:
+  bLength                 5
+  bDescriptorType        15
+  wTotalLength           22
+  bNumDeviceCaps          2
+  USB 2.0 Extension Device Capability:
+    bLength                 7
+    bDescriptorType        16
+    bDevCapabilityType      2
+    bmAttributes   0x00000002
+      HIRD Link Power Management (LPM) Supported
+  SuperSpeed USB Device Capability:
+    bLength                10
+    bDescriptorType        16
+    bDevCapabilityType      3
+    bmAttributes         0x00
+    wSpeedsSupported   0x000f
+      Device can operate at Low Speed (1Mbps)
+      Device can operate at Full Speed (12Mbps)
+      Device can operate at High Speed (480Mbps)
+      Device can operate at SuperSpeed (5Gbps)
+    bFunctionalitySupport   1
+      Lowest fully-functional device speed is Full Speed (12Mbps)
+    bU1DevExitLat           1 micro seconds
+    bU2DevExitLat         500 micro seconds
+Device Status:     0x0000
+  (Bus Powered)

--- a/laf_crypto.py
+++ b/laf_crypto.py
@@ -1,0 +1,37 @@
+import struct
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
+from lglaf import int_as_byte
+
+
+def key_transform(old_key):
+    new_key = b''
+    old_key = bytearray(old_key)
+    for x in range(32, 0, -1):
+        c = old_key[x-1]
+        new_key += int_as_byte(c - (x % 0x0C))
+    return new_key
+
+
+def xor_key(key, kilo_challenge):
+    # Reserve key
+    key_xor = b''
+    pos = 0
+    challenge = struct.unpack('>I', kilo_challenge)[0]
+    for i in range(8):
+        k = struct.unpack('<I', key[pos:pos + 4])[0]
+        key_xor += struct.pack('<I', k ^ challenge)
+        pos += 4
+    return key_xor
+
+
+def encrypt_kilo_challenge(encryption_key, kilo_challenge):
+    plaintext = b''
+    for k in range(0, 16):
+        # Assemble 0x00 0x01 0x02 ... 0x1F byte-array
+        plaintext += int_as_byte(k)
+    encryption_key = key_transform(encryption_key)
+    xored_key = xor_key(encryption_key, kilo_challenge)
+    obj = Cipher(algorithms.AES(xored_key), modes.ECB(),
+                 backend=default_backend()).encryptor()
+    return obj.update(plaintext) + obj.finalize()

--- a/lglaf.lua
+++ b/lglaf.lua
@@ -1,0 +1,105 @@
+-- Wireshark Dissector for LG LAF protocol
+-- Tested with Wireshark 2.0
+--
+-- Place it in ~/.config/wireshark/plugins/
+-- (or ~/.wireshark/plugins/ if ~/.wireshark/ exists)
+--
+-- Alternatively start with: wireshark -X lua_script:path/to/lglaf.lua
+
+local lglaf = Proto("lglaf", "LG LAF")
+
+local usb_transfer_type = Field.new("usb.transfer_type")
+local success, usb_endpoint = pcall(Field.new, "usb.endpoint_number")
+if not success then
+    -- Renamed since Wireshark v2.3.0rc0-1710-gf27f048ee1
+    usb_endpoint = Field.new("usb.endpoint_address")
+end
+
+lglaf.fields.cmd = ProtoField.string("lglaf.command", "Command")
+lglaf.fields.arg1 = ProtoField.uint32("lglaf.arg1", "Argument 1", base.HEX_DEC)
+lglaf.fields.arg2 = ProtoField.uint32("lglaf.arg2", "Argument 2", base.HEX_DEC)
+lglaf.fields.arg3 = ProtoField.uint32("lglaf.arg3", "Argument 3", base.HEX_DEC)
+lglaf.fields.arg4 = ProtoField.uint32("lglaf.arg4", "Argument 4", base.HEX_DEC)
+lglaf.fields.len = ProtoField.uint32("lglaf.len", "Body length")
+lglaf.fields.crc = ProtoField.uint32("lglaf.crc", "CRC", base.HEX)
+lglaf.fields.cmd_inv = ProtoField.bytes("lglaf.command_inv", "Command (inverted)")
+lglaf.fields.body = ProtoField.bytes("lglaf.body", "Body")
+lglaf.fields.body_str = ProtoField.string("lglaf.body_str", "Body (text)")
+
+function dissect_tx(tvb, pinfo, tree)
+    local i
+    local offset = 0
+    for i = 1, 2 do
+        tree:add_le(lglaf.fields.opts, tvb(offset, 4))
+        offset = offset + 4
+    end
+    return offset
+end
+
+function lglaf.dissector(tvb, pinfo, tree)
+    local offset
+    local transfer_type = usb_transfer_type().value
+    local endpoint = usb_endpoint().value
+
+    -- Process only bulk packets from (EP 5) and to the device (EP 3)
+    if not ((endpoint == 0x85 or endpoint == 3) and transfer_type == 3) then
+        return 0
+    end
+
+    pinfo.cols.protocol = lglaf.name
+
+    local lglaf_tree = tree:add(lglaf, tvb())
+    if tvb(0, 4):le_uint() ~= bit.bnot(tvb(0x1c, 4):le_uint()) then
+        pinfo.cols.info:set("Continuation")
+        return
+    end
+
+    local next_offset = 0
+    function add_dword(field)
+        next_offset = next_offset + 4
+        field_tvb = tvb(next_offset - 4, 4)
+        lglaf_tree:add_le(field, field_tvb)
+        return field_tvb
+    end
+    add_dword(lglaf.fields.cmd)
+    local v_args = {
+        add_dword(lglaf.fields.arg1),
+        add_dword(lglaf.fields.arg2),
+        add_dword(lglaf.fields.arg3),
+        add_dword(lglaf.fields.arg4),
+    }
+    local v_len = add_dword(lglaf.fields.len)
+    add_dword(lglaf.fields.crc)
+    add_dword(lglaf.fields.cmd_inv)
+
+    pinfo.cols.info:set(tvb(0, 4):string() .. "(")
+    for i, arg in ipairs(v_args) do
+        if i > 1 then
+            pinfo.cols.info:append(",");
+        end
+        pinfo.cols.info:append(arg:le_uint())
+    end
+    pinfo.cols.info:append(")")
+
+    -- TODO desegmentation support
+    local body_len = v_len:le_uint()
+    if body_len > 0 then
+        local body_tvb = tvb(next_offset, body_len)
+        lglaf_tree:add(lglaf.fields.body, body_tvb)
+        lglaf_tree:add(lglaf.fields.body_str, body_tvb)
+
+        local body_summary = body_tvb:string()
+        body_summary = string.gsub(body_summary, "\n", "\\n")
+        if #body_summary > 50 then
+            body_summary = string.sub(body_summary, 1, 80) .. "…"
+        end
+        pinfo.cols.info:append(" [" .. body_len ..  "] " .. body_summary)
+    end
+end
+
+function lglaf.init()
+    local usb_product = DissectorTable.get("usb.product");
+    usb_product:add(0x1004633e, lglaf) -- LG G3 (D855) or LG V10 (H962)
+    usb_product:add(0x1004627f, lglaf) -- LG G3 (VS985)
+    usb_product:add(0x10046298, lglaf) -- LG G4 (VS986)
+end

--- a/lglaf.py
+++ b/lglaf.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python
+#
+# Interactive shell for communication with LG devices in download mode (LAF).
+#
+# Copyright (C) 2015 Peter Wu <peter@lekensteyn.nl>
+# Licensed under the MIT license <http://opensource.org/licenses/MIT>.
+
+from __future__ import print_function
+from contextlib import closing
+import argparse, logging, re, struct, sys, binascii
+
+# Enhanced prompt with history
+try: import readline
+except ImportError: pass
+# Try USB interface
+try: import usb.core, usb.util
+except ImportError: pass
+# Windows registry for serial port detection
+try: import winreg
+except ImportError:
+    try: import _winreg as winreg
+    except ImportError: winreg = None
+
+_logger = logging.getLogger("LGLAF.py")
+
+# Python 2/3 compat
+try:
+    input = raw_input
+except:
+    pass
+
+if '\0' == b'\0':
+    int_as_byte = chr
+else:
+    int_as_byte = lambda x: bytes([x])
+
+# laf crypto for KILO challenge/response
+try:
+    import laf_crypto
+except ImportError as e:
+    _logger.warning("LAF Crypto failed to import! Error: %s" % e)
+    pass
+
+# Use Manufacturer key for KILO challenge/response
+USE_MFG_KEY = False
+
+laf_error_codes = {
+    0x80000000: "FAILED",
+    0x80000001: "INVALID_PARAMETER",
+    0x80000002: "INVALID_HANDLE",
+    0x80000003: "DEVICE_NOT_SUPPORTED",
+    0x80000004: "INTERNAL_ERROR",
+    0x80000005: "TIMEOUT",
+    0x8000000F: "MORE_HEADER_DATA",
+    0x80000010: "MORE_DATA",
+    0x80000011: "INVALID_DATA",
+    0x80000012: "INVALID_DATA_LENGTH",
+    0x80000013: "INVALID_PACKET",
+    0x80000016: "CRC_CHECKSUM",
+    0x80000017: "CMD_CODE",
+    0x80000018: "OUTOFMEMORY",
+    0x80000105: "INVALID_NAME",
+    0x80000106: "NOT_CONNECTED",
+    0x80000107: "CANNOT_MAKE",
+    0x80000108: "FILE_NOT_FOUND",
+    0x80000109: "NOT_ENOUGH_QUOTA",
+    0x8000010a: "ACCESS_DENIED",
+    0x8000010c: "CANCELLED",
+    0x8000010d: "CONNECTION_ABORTED",
+    0x8000010e: "CONTINUE",
+    0x8000010f: "GEN_FAILURE",
+    0x80000110: "INCORRECT_ADDRESS",
+    0x80000111: "INVALID_CATEGORY",
+    0x80000112: "REQUEST_ABORTED",
+    0x80000113: "RETRY",
+    0x80000116: "DEVICE_NOT_AVAILABLE",
+    0x80000201: "IDT_MISMATCH_MODELNAME",
+    0x80000202: "IDT_DECOMPRES_FAILED",
+    0x80000203: "IDT_INVALID_OPTION",
+    0x80000204: "IDT_DECOMPRESS_END_FAILED",
+    0x80000205: "IDT_DZ_HEADER",
+    0x80000206: "IDT_RETRY_COUNT",
+    0x80000207: "IDT_HEADER_SIZE",
+    0x80000208: "IDT_TOT_MAGIC",
+    0x80000209: "UDT_DZ_HEADER_SIZE",
+    0x80000302: "INVALID_RESPONSE",
+    0x80000305: "FAILED_INSERT_QUEUE",
+    0x80000306: "FAILED_POP_QUEUE",
+    0x80000307: "INVALID_LAF_PROTOCOL",
+    0x80000308: "ERASE_FAILED",
+    0x80000309: "WEBFLAG_RESET_FAIL",
+    0x80000401: "FLASHING_FAIL",
+    0x80000402: "SECURE_FAIL",
+    0x80000403: "BUILD_TYPE_FAIL",
+    0x80000404: "CHECK_USER_SPC",
+    0x80000405: "FBOOT_CHECK_FAIL",
+    0x80000406: "INIT_FAIL",
+    0x80000407: "FRST_FLAG_FAIL",
+    0x80000408: "POWER_OFF_FAIL",
+    0x8000040a: "PRL_READ_FAIL",
+    0x80000409: "PRL_WRITE_FAIL",
+}
+
+
+_ESCAPE_PATTERN = re.compile(b'''\\\\(
+x[0-9a-fA-F]{2} |
+[0-7]{1,3} |
+.)''', re.VERBOSE)
+_ESCAPE_MAP = {
+    b'n': b'\n',
+    b'r': b'\r',
+    b't': b'\t',
+}
+_ESCAPED_CHARS = b'"\\\''
+def text_unescape(text):
+    """Converts a string with escape sequences to bytes."""
+    text_bin = text.encode("utf8")
+    def sub_char(m):
+        what = m.group(1)
+        if what[0:1] == b'x' and len(what) == 3:
+            return int_as_byte(int(what[1:], 16))
+        elif what[0:1] in b'01234567':
+            return int_as_byte(int(what, 8))
+        elif what in _ESCAPE_MAP:
+            return _ESCAPE_MAP[what]
+        elif what in _ESCAPED_CHARS:
+            return what
+        else:
+            raise RuntimeError('Unknown escape sequence \\%s' %
+                    what.decode('utf8'))
+    return re.sub(_ESCAPE_PATTERN, sub_char, text_bin)
+
+def parse_number_or_escape(text):
+    try:
+        return int(text, 0) if text else 0
+    except ValueError:
+        return text_unescape(text)
+
+### Protocol-related stuff
+
+def crc16(data):
+    """CRC-16-CCITT computation with LSB-first and inversion."""
+    crc = 0xffff
+    for byte in data:
+        crc ^= byte
+        for bits in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0x8408
+            else:
+                crc >>= 1
+    return crc ^ 0xffff
+
+def invert_dword(dword_bin):
+    dword = struct.unpack("I", dword_bin)[0]
+    return struct.pack("I", dword ^ 0xffffffff)
+
+def make_request(cmd, args=[], body=b''):
+    if not isinstance(cmd, bytes):
+        cmd = cmd.encode('ascii')
+    assert isinstance(body, bytes), "body must be bytes"
+
+    # Header: command, args, ... body size, header crc16, inverted command
+    header = bytearray(0x20)
+    def set_header(offset, val):
+        if isinstance(val, int):
+            val = struct.pack('<I', val)
+        assert len(val) == 4, "Header field requires a DWORD, got %s %r" % \
+                (type(val).__name__, val)
+        header[offset:offset+4] = val
+
+    set_header(0, cmd)
+    assert len(args) <= 4, "Header cannot have more than 4 arguments"
+    for i, arg in enumerate(args):
+        set_header(4 * (i + 1), arg)
+
+    # 0x14: body length
+    set_header(0x14, len(body))
+    # 0x1c: Inverted command
+    set_header(0x1c, invert_dword(cmd))
+    # Header finished (with CRC placeholder), append body...
+    header += body
+    # finish with CRC for header and body
+    set_header(0x18, crc16(header))
+    return bytes(header)
+
+def validate_message(payload, ignore_crc=False):
+    if len(payload) < 0x20:
+        raise RuntimeError("Invalid header length: %d" % len(payload))
+    if not ignore_crc:
+        crc = struct.unpack_from('<I', payload, 0x18)[0]
+        payload_before_crc = bytearray(payload)
+        payload_before_crc[0x18:0x18+4] = b'\0\0\0\0'
+        crc_exp = crc16(payload_before_crc)
+        if crc_exp != crc:
+            raise RuntimeError("Expected CRC %04x, found %04x" % (crc_exp, crc))
+    tail_exp = invert_dword(payload[0:4])
+    tail = payload[0x1c:0x1c+4]
+    if tail_exp != tail:
+        raise RuntimeError("Expected trailer %r, found %r" % (tail_exp, tail))
+
+def make_exec_request(shell_command, rawshell):
+    # Allow use of shell constructs such as piping and reports syntax errors
+    # such as unterminated quotes. Remaining limitation: repetitive spaces are
+    # still eaten.
+    # If rawshell is set, execute the command as it's provided
+    if rawshell:
+        argv = b''
+    else:
+        argv = b'sh -c eval\t"$*"</dev/null\t2>&1 -- '
+    argv += shell_command.encode('ascii')
+    if len(argv) > 255:
+        raise RuntimeError("Command length %d is larger than 255" % len(argv))
+    return make_request(b'EXEC', body=argv + b'\0')
+
+
+### USB or serial port communication
+
+class Communication(object):
+    def __init__(self):
+        self.read_buffer = b''
+    def read(self, n, timeout=None):
+        """Reads exactly n bytes."""
+        need = n - len(self.read_buffer)
+        while need > 0:
+            buff = self._read(need, timeout=timeout)
+            self.read_buffer += buff
+            if not buff:
+                raise EOFError
+            need -= len(buff)
+        data, self.read_buffer = self.read_buffer[0:n], self.read_buffer[n:]
+        return data
+    def _read(self, n, timeout=None):
+        """Try one read, possibly returning less or more than n bytes."""
+        raise NotImplementedError
+    def write(self, data):
+        raise NotImplementedError
+    def close(self):
+        raise NotImplementedError
+    def reset(self):
+        self.read_buffer = b''
+    def call(self, payload):
+        """Sends a command and returns its response."""
+        validate_message(payload)
+        self.write(payload)
+        header = self.read(0x20)
+        validate_message(header, ignore_crc=True)
+        cmd = header[0:4]
+        size = struct.unpack_from('<I', header, 0x14)[0]
+        # could validate CRC and inverted command here...
+        data = self.read(size) if size else b''
+        if cmd == b'FAIL':
+            errCode = struct.unpack_from('<I', header, 4)[0]
+            msg = 'LAF_ERROR_%s' % laf_error_codes.get(errCode, '<unknown>')
+            raise RuntimeError('Command failed with error code %#x (%s)' % (errCode, msg))
+        if cmd != payload[0:4]:
+            raise RuntimeError("Unexpected response: %r" % header)
+        return header, data
+
+class FileCommunication(Communication):
+    def __init__(self, file_path):
+        super(FileCommunication, self).__init__()
+        if sys.version_info[0] >= 3:
+            self.f = open(file_path, 'r+b', buffering=0)
+        else:
+            self.f = open(file_path, 'r+b')
+    def _read(self, n, timeout=None):
+        return self.f.read(n)
+    def write(self, data):
+        self.f.write(data)
+    def close(self):
+        self.f.close()
+
+class USBCommunication(Communication):
+    VENDOR_ID_LG = 0x1004
+    # Read timeout. Set to 0 to disable timeouts
+    READ_TIMEOUT_MS = 60000
+    def __init__(self):
+        super(USBCommunication, self).__init__()
+        # Match device using heuristics on the interface/endpoint descriptors,
+        # this avoids hardcoding idProduct.
+        self.usbdev = usb.core.find(idVendor=self.VENDOR_ID_LG,
+                custom_match = self._match_device)
+        if self.usbdev is None:
+            raise RuntimeError("USB device not found")
+        cfg = usb.util.find_descriptor(self.usbdev,
+                custom_match=self._match_configuration)
+        current_cfg = self.usbdev.get_active_configuration()
+        if cfg.bConfigurationValue != current_cfg.bConfigurationValue:
+            try:
+                cfg.set()
+            except usb.core.USBError as e:
+                _logger.warning("Failed to set configuration, "
+                        "has a kernel driver claimed the interface?")
+                raise e
+        for intf in cfg:
+            if self.usbdev.is_kernel_driver_active(intf.bInterfaceNumber):
+                _logger.debug("Detaching kernel driver for intf %d",
+                        intf.bInterfaceNumber)
+                self.usbdev.detach_kernel_driver(intf.bInterfaceNumber)
+            if self._match_interface(intf):
+                self._set_interface(intf)
+        assert self.ep_in
+        assert self.ep_out
+    def _match_device(self, device):
+        return any(
+            usb.util.find_descriptor(cfg, custom_match=self._match_interface)
+            for cfg in device
+        )
+    def _set_interface(self, intf):
+        for ep in intf:
+            ep_dir = usb.util.endpoint_direction(ep.bEndpointAddress)
+            if ep_dir == usb.util.ENDPOINT_IN:
+                self.ep_in = ep.bEndpointAddress
+            else:
+                self.ep_out = ep.bEndpointAddress
+        _logger.debug("Using endpoints %02x (IN), %02x (OUT)",
+                self.ep_in, self.ep_out)
+    def _match_interface(self, intf):
+        return intf.bInterfaceClass == 255 and \
+            intf.bInterfaceSubClass == 255 and \
+            intf.bInterfaceProtocol == 255 and \
+            intf.bNumEndpoints == 2 and all(
+            usb.util.endpoint_type(ep.bmAttributes) ==
+                usb.util.ENDPOINT_TYPE_BULK
+            for ep in intf
+        )
+    def _match_configuration(self, config):
+        return usb.util.find_descriptor(config,
+                custom_match=self._match_interface)
+    def _read(self, n, timeout=None):
+        if timeout is None:
+            timeout = self.READ_TIMEOUT_MS
+        # device seems to use 16 KiB buffers.
+        array = self.usbdev.read(self.ep_in, 2**14, timeout=timeout)
+        try: return array.tobytes()
+        except: return array.tostring()
+    def write(self, data):
+        # Reset read buffer for response
+        if self.read_buffer:
+            _logger.warning('non-empty read buffer %r', self.read_buffer)
+            self.read_buffer = b''
+        self.usbdev.write(self.ep_out, data)
+    def close(self):
+        usb.util.dispose_resources(self.usbdev)
+
+def challenge_response(comm, mode):
+    request_kilo = make_request(b'KILO', args=[b'CENT', b'\0\0\0\0', b'\0\0\0\0', b'\0\0\0\0'])
+    kilo_header, kilo_response = comm.call(request_kilo)
+    kilo_challenge = kilo_header[8:12]
+    _logger.debug("Challenge: %s" % binascii.hexlify(kilo_challenge))
+    if USE_MFG_KEY:
+        key = b'lgowvqnltpvtgogwswqn~n~mtjjjqxro'
+    else:
+        key = b'qndiakxxuiemdklseqid~a~niq,zjuxl'
+    kilo_response = laf_crypto.encrypt_kilo_challenge(key, kilo_challenge)
+    _logger.debug("Response: %s" % binascii.hexlify(kilo_response))
+    mode_bytes = struct.pack('<I', mode)
+    kilo_metr_request = make_request(b'KILO', args=[b'METR', b'\0\0\0\0', mode_bytes, b'\0\0\0\0'],
+                                     body=bytes(kilo_response))
+    metr_header, metr_response = comm.call(kilo_metr_request)
+    _logger.debug("KILO METR Response -> Header: %s, Body: %s" % (
+        binascii.hexlify(metr_header), binascii.hexlify(metr_response)))
+
+def try_hello(comm):
+    """
+    Tests whether the device speaks the expected protocol. If desynchronization
+    is detected, tries to read as much data as possible.
+    """
+    # Wait for at most 5 seconds for a response... it shouldn't take that long
+    # and otherwise something is wrong.
+    HELLO_READ_TIMEOUT = 5000
+
+    hello_request = make_request(b'HELO', args=[b'\1\0\0\1'])
+    comm.write(hello_request)
+    data = comm.read(0x20, timeout=HELLO_READ_TIMEOUT)
+    if data[0:4] != b'HELO':
+        # Unexpected response, maybe some stale data from a previous execution?
+        while data[0:4] != b'HELO':
+            try:
+                validate_message(data, ignore_crc=True)
+                size = struct.unpack_from('<I', data, 0x14)[0]
+                comm.read(size, timeout=HELLO_READ_TIMEOUT)
+            except RuntimeError: pass
+            # Flush read buffer
+            comm.reset()
+            data = comm.read(0x20, timeout=HELLO_READ_TIMEOUT)
+        # Just to be sure, send another HELO request.
+        comm.call(hello_request)
+
+
+def detect_serial_path():
+    try:
+        path = r'HARDWARE\DEVICEMAP\SERIALCOMM'
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, path) as key:
+            for i in range(winreg.QueryInfoKey(key)[1]):
+                name, value, value_type = winreg.EnumValue(key, i)
+                # match both \Device\LGANDNETDIAG1 and \Device\LGVZANDNETDIAG1
+                name = name.upper()
+                if name.startswith(r'\DEVICE\LG') and name.endswith('ANDNETDIAG1'):
+                    return value
+    except OSError: pass
+    return None
+
+def autodetect_device():
+    if winreg is not None and 'usb.core' not in sys.modules:
+        serial_path = detect_serial_path()
+        _logger.debug("Using serial port: %s", serial_path)
+        if not serial_path:
+            raise RuntimeError("Device not found, try installing LG drivers")
+        return FileCommunication(serial_path)
+    else:
+        if 'usb.core' not in sys.modules:
+            raise RuntimeError("Please install PyUSB for USB support")
+        return USBCommunication()
+
+
+### Interactive loop
+
+def get_commands(command):
+    if command:
+        yield command
+        return
+    # Happened on Win32/Py3.4.4 when: echo ls | lglaf.py --serial com4
+    if sys.stdin is None:
+        raise RuntimeError('No console input available!')
+    if sys.stdin.isatty():
+        print("LGLAF.py by Peter Wu (https://lekensteyn.nl/lglaf)\n"
+                "Type a shell command to execute or \"exit\" to leave.",
+                file=sys.stderr)
+        prompt = '# '
+    else:
+        prompt = ''
+    try:
+        while True:
+            line = input(prompt)
+            if line == "exit":
+                break
+            if line:
+                yield line
+    except EOFError:
+        if prompt:
+            print("", file=sys.stderr)
+
+def command_to_payload(command, rawshell):
+    # Handle '!' as special commands, treat others as shell command
+    if command[0] != '!':
+        return make_exec_request(command, rawshell)
+    command = command[1:]
+    # !command [arg1[,arg2[,arg3[,arg4]]]] [body]
+    # args are treated as integers (decimal or hex)
+    # body is treated as string (escape sequences are supported)
+    command, args, body = (command.split(' ', 2) + ['', ''])[0:3]
+    command = text_unescape(command)
+    args = list(map(parse_number_or_escape, args.split(',') + [0, 0, 0]))[0:4]
+    body = text_unescape(body)
+    return make_request(command, args, body)
+
+parser = argparse.ArgumentParser(description='LG LAF Download Mode utility')
+parser.add_argument("--skip-hello", action="store_true",
+        help="Immediately send commands, skip HELO message")
+parser.add_argument("--cr", action="store_true",
+        help="Do initial challenge response (KILO CENT/METR)")
+parser.add_argument('--rawshell', action="store_true",
+        help="Execute shell commands as-is, needed on recent devices. "
+             "CAUTION: stderr output is not redirected!")
+parser.add_argument("-c", "--command", help='Shell command to execute')
+parser.add_argument("--serial", metavar="PATH", dest="serial_path",
+        help="Path to serial device (e.g. COM4).")
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+
+def main():
+    args = parser.parse_args()
+    logging.basicConfig(format='%(name)s: %(levelname)s: %(message)s',
+            level=logging.DEBUG if args.debug else logging.INFO)
+
+    # Binary stdout (output data from device as-is)
+    try: stdout_bin = sys.stdout.buffer
+    except: stdout_bin = sys.stdout
+
+    if args.serial_path:
+        comm = FileCommunication(args.serial_path)
+    else:
+        comm = autodetect_device()
+
+    with closing(comm):
+        if args.cr:
+            # Mode 2 seems standard, will maybe
+            # change in other protocol versions
+            _logger.debug("Doing KILO challenge response")
+            challenge_response(comm, mode=2)
+        if not args.skip_hello:
+            try_hello(comm)
+            _logger.debug("Hello done, proceeding with commands")
+        for command in get_commands(args.command):
+            try:
+                payload = command_to_payload(command, args.rawshell)
+                header, response = comm.call(payload)
+                # For debugging, print header
+                if command[0] == '!':
+                    _logger.debug('Header: %s',
+                            ' '.join(repr(header[i:i+4]).replace("\\x00", "\\0")
+                        for i in range(0, len(header), 4)))
+                stdout_bin.write(response)
+            except Exception as e:
+                _logger.warning(e)
+                if args.debug:
+                    import traceback; traceback.print_exc()
+
+if __name__ == '__main__':
+    main()

--- a/partitions.py
+++ b/partitions.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python
+#
+# Manage a single partition (info, read, write).
+#
+# Copyright (C) 2015 Peter Wu <peter@lekensteyn.nl>
+# Licensed under the MIT license <http://opensource.org/licenses/MIT>.
+
+from __future__ import print_function
+from collections import OrderedDict
+from contextlib import closing, contextmanager
+import argparse, logging, os, io, struct, sys
+import lglaf
+import gpt
+
+_logger = logging.getLogger("partitions")
+
+GPT_LBA_LEN = 34
+
+def human_readable(sz):
+    suffixes = ('', 'Ki', 'Mi', 'Gi', 'Ti')
+    for i, suffix in enumerate(suffixes):
+        if sz <= 1024**(i+1):
+            break
+    return '%.1f %sB' % (sz / 1024**i, suffix)
+
+def read_uint32(data, offset):
+    return struct.unpack_from('<I', data, offset)[0]
+
+def get_partitions(comm, fd_num):
+    """
+    Maps partition labels (such as "recovery") to block devices (such as
+    "mmcblk0p0"), sorted by the number in the block device.
+    """
+    read_offset = 0
+    end_offset = GPT_LBA_LEN * BLOCK_SIZE
+
+    table_data = b''
+    while read_offset < end_offset:
+        chunksize = min(end_offset - read_offset, BLOCK_SIZE * MAX_BLOCK_SIZE)
+        data = laf_read(comm, fd_num, read_offset // BLOCK_SIZE, chunksize)
+        table_data += data
+        read_offset += chunksize
+
+    with io.BytesIO(table_data) as table_fd:
+        info = gpt.get_disk_partitions_info(table_fd)
+    return info
+
+def find_partition(diskinfo, query):
+    partno = int(query) if query.isdigit() else None
+    for part in diskinfo.gpt.partitions:
+        if part.index == partno or part.name == query:
+            return part
+    raise ValueError("Partition not found: %s" % query)
+
+@contextmanager
+def laf_open_disk(comm):
+    # Open whole disk in read/write mode
+    open_cmd = lglaf.make_request(b'OPEN', body=b'\0')
+    open_header = comm.call(open_cmd)[0]
+    fd_num = read_uint32(open_header, 4)
+    try:
+        yield fd_num
+    finally:
+        close_cmd = lglaf.make_request(b'CLSE', args=[fd_num])
+        comm.call(close_cmd)
+
+def laf_read(comm, fd_num, offset, size):
+    """Read size bytes at the given block offset."""
+    read_cmd = lglaf.make_request(b'READ', args=[fd_num, offset, size])
+    header, response = comm.call(read_cmd)
+    # Ensure that response fd, offset and length are sane (match the request)
+    assert read_cmd[4:4+12] == header[4:4+12], "Unexpected read response"
+    assert len(response) == size
+    return response
+
+def laf_erase(comm, fd_num, sector_start, sector_count):
+    """TRIM some sectors."""
+    erase_cmd = lglaf.make_request(b'ERSE',
+            args=[fd_num, sector_start, sector_count])
+    header, response = comm.call(erase_cmd)
+    # Ensure that response fd, start and count are sane (match the request)
+    assert erase_cmd[4:4+12] == header[4:4+12], "Unexpected erase response"
+
+def laf_write(comm, fd_num, offset, data):
+    """Write size bytes at the given block offset."""
+    #_logger.debug("WRTE(0x%05x, #%d)", offset, len(data)); return
+    write_cmd = lglaf.make_request(b'WRTE', args=[fd_num, offset], body=data)
+    header = comm.call(write_cmd)[0]
+    # Response offset (in bytes) must match calculated offset
+    calc_offset = (offset * 512) & 0xffffffff
+    resp_offset = read_uint32(header, 8)
+    assert write_cmd[4:4+4] == header[4:4+4], "Unexpected write response"
+    assert calc_offset == resp_offset, \
+            "Unexpected write response: %#x != %#x" % (calc_offset, resp_offset)
+
+def open_local_writable(path):
+    if path == '-':
+        try: return sys.stdout.buffer
+        except: return sys.stdout
+    else:
+        return open(path, "wb")
+
+def open_local_readable(path):
+    if path == '-':
+        try: return sys.stdin.buffer
+        except: return sys.stdin
+    else:
+        return open(path, "rb")
+
+def get_partition_info_string(part):
+    info = '#   Flags From(#s)   To(#s)     GUID/UID                             Type/Name\n'
+    info += ('{n: <3} {flags: ^5} {from_s: <10} {to_s: <10} {guid} {type}\n' + ' ' * 32 + '{uid} {name}').format(
+                n=part.index, flags=part.flags, from_s=part.first_lba, to_s=part.last_lba, guid=part.guid,
+                type=part.type, uid=part.uid, name=part.name)
+    return info
+
+def list_partitions(comm, fd_num, part_filter=None):
+    diskinfo = get_partitions(comm, fd_num)
+    if part_filter:
+        try:
+            part = find_partition(diskinfo, part_filter)
+            print(get_partition_info_string(part))
+        except ValueError as e:
+            print('Error: %s' % e)
+    else:
+        gpt.show_disk_partitions_info(diskinfo)
+
+# On Linux, one bulk read returns at most 16 KiB. 32 bytes are part of the first
+# header, so remove one block size (512 bytes) to stay within that margin.
+# This ensures that whenever the USB communication gets out of sync, it will
+# always start with a message header, making recovery easier.
+MAX_BLOCK_SIZE = (16 * 1024 - 512) // 512
+BLOCK_SIZE = 512
+
+def dump_partition(comm, disk_fd, local_path, part_offset, part_size):
+    # Read offsets must be a multiple of 512 bytes, enforce this
+    read_offset = BLOCK_SIZE * (part_offset // BLOCK_SIZE)
+    end_offset = part_offset + part_size
+    unaligned_bytes = part_offset % BLOCK_SIZE
+    _logger.debug("Will read %d bytes at disk offset %d", part_size, part_offset)
+    if unaligned_bytes:
+        _logger.debug("Unaligned read, read will start at %d", read_offset)
+
+    with open_local_writable(local_path) as f:
+        # Offset should be aligned to block size. If not, read at most a
+        # whole block and drop the leading bytes.
+        if unaligned_bytes:
+            chunksize = min(end_offset - read_offset, BLOCK_SIZE)
+            data = laf_read(comm, disk_fd, read_offset // BLOCK_SIZE, chunksize)
+            f.write(data[unaligned_bytes:])
+            read_offset += BLOCK_SIZE
+
+        while read_offset < end_offset:
+            chunksize = min(end_offset - read_offset, BLOCK_SIZE * MAX_BLOCK_SIZE)
+            data = laf_read(comm, disk_fd, read_offset // BLOCK_SIZE, chunksize)
+            f.write(data)
+            read_offset += chunksize
+        _logger.info("Wrote %d bytes to %s", part_size, local_path)
+
+def write_partition(comm, disk_fd, local_path, part_offset, part_size):
+    write_offset = BLOCK_SIZE * (part_offset // BLOCK_SIZE)
+    end_offset = part_offset + part_size
+    # TODO support unaligned writes via read/modify/write
+    if part_offset % BLOCK_SIZE:
+        raise RuntimeError("Unaligned partition writes are not supported yet")
+
+    # Sanity check
+    assert part_offset >= 34 * 512, "Will not allow overwriting GPT scheme"
+
+    with open_local_readable(local_path) as f:
+        try:
+            length = f.seek(0, 2)
+        except OSError:
+            # Will try to write up to the end of the file.
+            _logger.debug("File %s is not seekable, length is unknown",
+                    local_path)
+        else:
+            # Restore position and check if file is small enough
+            f.seek(0)
+            if length > part_size:
+                raise RuntimeError("File size %d is larger than partition "
+                        "size %d" % (length, part_size))
+            # Some special bytes report 0 (such as /dev/zero)
+            if length > 0:
+                _logger.debug("Will write %d bytes", length)
+
+        written = 0
+        while write_offset < end_offset:
+            chunksize = min(end_offset - write_offset, BLOCK_SIZE * MAX_BLOCK_SIZE)
+            data = f.read(chunksize)
+            if not data:
+                break # End of file
+            laf_write(comm, disk_fd, write_offset // BLOCK_SIZE, data)
+            written += len(data)
+            write_offset += chunksize
+            if len(data) != chunksize:
+                break # Short read, end of file
+        _logger.info("Done after writing %d bytes from %s", written, local_path)
+
+def wipe_partition(comm, disk_fd, part_offset, part_size):
+    sector_start = part_offset // BLOCK_SIZE
+    sector_count = part_size // BLOCK_SIZE
+
+    # Sanity check
+    assert sector_start >= 34, "Will not allow overwriting GPT scheme"
+    # Discarding no sectors or more than 512 GiB is a bit stupid.
+    assert 0 < sector_count < 1024**3, "Invalid sector count %d" % sector_count
+
+    laf_erase(comm, disk_fd, sector_start, sector_count)
+    _logger.info("Done with TRIM from sector %d, count %d (%s)",
+            sector_start, sector_count, human_readable(part_size))
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+parser.add_argument("--list", action='store_true',
+        help='List available partitions')
+parser.add_argument("--dump", metavar="LOCAL_PATH",
+        help="Dump partition to file ('-' for stdout)")
+parser.add_argument("--restore", metavar="LOCAL_PATH",
+        help="Write file to partition on device ('-' for stdin)")
+parser.add_argument("--wipe", action='store_true',
+        help="TRIMs a partition")
+parser.add_argument("partition", nargs='?',
+        help="Partition number (e.g. 1 for block device mmcblk0p1)"
+        " or partition name (e.g. 'recovery')")
+parser.add_argument("--skip-hello", action="store_true",
+        help="Immediately send commands, skip HELO message")
+
+def main():
+    args = parser.parse_args()
+    logging.basicConfig(format='%(asctime)s %(name)s: %(levelname)s: %(message)s',
+            level=logging.DEBUG if args.debug else logging.INFO)
+
+    actions = (args.list, args.dump, args.restore, args.wipe)
+    if sum(1 if x else 0 for x in actions) != 1:
+        parser.error("Please specify one action from"
+        " --list / --dump / --restore / --wipe")
+    if not args.partition and (args.dump or args.restore or args.wipe):
+        parser.error("Please specify a partition")
+
+    comm = lglaf.autodetect_device()
+    with closing(comm):
+        
+        if not args.skip_hello:
+            lglaf.try_hello(comm)
+
+        with laf_open_disk(comm) as disk_fd:
+            if args.list:
+                list_partitions(comm, disk_fd, args.partition)
+                return
+
+            diskinfo = get_partitions(comm, disk_fd)
+            try:
+                part = find_partition(diskinfo, args.partition)
+            except ValueError as e:
+                parser.error(e)
+
+            info = get_partition_info_string(part)
+            _logger.debug("%s", info)
+
+            part_offset = part.first_lba * BLOCK_SIZE
+            part_size = (part.last_lba - (part.first_lba - 1)) * BLOCK_SIZE
+
+            _logger.debug("Opened fd %d for disk", disk_fd)
+            if args.dump:
+                dump_partition(comm, disk_fd, args.dump, part_offset, part_size)
+            elif args.restore:
+                write_partition(comm, disk_fd, args.restore, part_offset, part_size)
+            elif args.wipe:
+                wipe_partition(comm, disk_fd, part_offset, part_size)
+
+if __name__ == '__main__':
+    try:
+        main()
+    except OSError as e:
+        # Ignore when stdout is closed in a pipe
+        if e.errno != 32:
+            raise

--- a/protocol.md
+++ b/protocol.md
@@ -1,0 +1,400 @@
+# LG LAF Protocol
+This document is a reverse-engineered protocol description for LG Advanced Flash
+(LAF), the download mode offered by various LG models. It is based on analysis
+on the `Send_Command.exe` utility and `LGD855_20140526_LGFLASHv160.dll` file and
+a USB trace using Wireshark and usbmon on Linux. Some commands were found in the
+`/sbin/lafd` binary.
+
+This document uses the following conventions for types:
+
+ - `\xaa\xbb\xcc\xdd` denotes a byte pattern `aa bb cc dd`.
+ - `0xddccbbaa` denotes a 32-bit integer in hexadecimal format. It represents
+   the same byte pattern as `\xaa\xbb\xcc\xdd`.
+
+## Overview
+LAF is a simple request/response protocol operating over USB. The USB details
+are described at the end of the document, the messages are described below.
+
+Each message consists of a header, followed by an optional body. The header
+contains 32-bit DWORDs, integers are encoded in little-endian form:
+
+| Offset (hex) | Offset (dec) | Type | Description
+| ----:| --:| ------- | ---
+| 0x00 | 0  | char[4] | Command
+| 0x04 | 4  | var     | Argument 1
+| 0x08 | 8  | var     | Argument 2
+| 0x0c | 12 | var     | Argument 3
+| 0x10 | 16 | var     | Argument 4
+| 0x14 | 20 | int     | Body length
+| 0x18 | 24 | int     | CRC-16
+| 0x1c | 28 | char[4] | Bit-wise invertion of command at offset 0
+
+Arguments can be integers or character sequences depending on the command.
+
+The CRC field is the CRC-16-CCITT calculation (LSB-first) over the header and
+the body with zeroes in place of CRC.
+
+Each request is followed by a response with a matching command field. If an
+error occurs, the response contains command is `FAIL` with argument 1 being the
+error code and the original request header as body.
+
+## Commands
+
+### OPEN - Open File
+Opens a file path.
+
+Arguments:
+ - arg1 (response): DWORD file descriptor.
+
+Request body: NUL-terminated file path that should be opened for reading or an
+ empty string to open `/dev/block/mmcblk0` in read/write mode.
+(at most 276 (0x114) bytes?)
+
+Non-existing files result in FAIL with error code 0x80000001.
+
+On newer versions, this requires authentication via `KILO` command.
+
+### CLSE - Close File
+Closes a file descriptor which was returned by the `OPEN` command.
+
+Arguments:
+ - arg1: DWORD file descriptor (same in request and response).
+
+Note: this allows you to close any file descriptor that are in use by the `lafd`
+process, not just the one returned by `OPEN`. You can discover the current file
+descriptors via `ls -l /proc/$pid/fd` where `$pid` is found by `ps | grep lafd`.
+
+### HELO - Hello
+Arguments:
+ - arg1: DWORD Protocol Version (`\1\0\0\1`) (resp must match req.)
+ - arg2 (response): Minimum Protocol Version (`\0\0\x80\0` was observed)
+
+### CTRL - Control
+Reboot or power off.
+Arguments:
+ - arg1: sub-command:
+    - `POFF`: power off
+    - `RSON`: restart lafd
+    - `RSET`: reboot with param `oem-90466252` (normal reboot)
+    - `ONRS`: reboot with param `oem-02179092`
+    - `AATD`: reboot with param `aat_enter`
+
+Note: `CTRL(RSET)` with no body is sent by the `Send_Command.exe` utility for
+the `LEAVE` command.
+
+LG Flash DLL waits 5000 milliseconds after this command.
+
+Purpose of `ONRS` and `AATD` are unknown. Both seem to reboot normally. Probably
+one is meant to enter fastboot?
+
+### WRTE - Write File
+Writes to a file descriptor.
+
+Arguments:
+ - arg1: file descriptor (must be open for writing!)
+ - arg2 (request): offset in **blocks** (multiple of 512 bytes).
+ - arg2 (response): offset in **bytes**.
+
+Request body: the data to be written. Can be of any size (including 1 or 513).
+
+Note: writing to a file descriptor which was opened for reading results in FAIL
+with code 0x82000002. This command is likely used for writing to partitions.
+
+Integer overflow in the response offset is ignored. That is, the block offset
+30736384 (0x1d50000) is 0x3aa000000 bytes, but will appear as 0xaa000000.
+
+This can be used to write to already-opened files without authentication, but
+lafd doesn't appear to have any files opened for writing by default.
+
+### READ - Read File
+Reads from a file descriptor.
+
+Arguments:
+ - arg1: file descriptor.
+ - arg2: offset in **blocks** (multiple of 512 bytes).
+ - arg3: requested length in bytes (at most 8MiB).
+ - arg4: "whence" seek mode (see below).
+
+Response body: data in file at given offset and requested length.
+
+Note: be sure not to read past the end of the file (512 * offset + length), this
+will hang the communication, requiring a reset (pull out battery)!
+
+Arg4 affects the seek mode, values for request:
+ - 0 (`SEEK_SET`) - seek to `512 * offset`.
+ - 1 (`SEEK_CUR`) - read from current position (offset argument is ignored).
+ - 2 (`SEEK_END`) - kind of useless when all offsets are unsigned...
+ - 3 (`SEEK_DATA`) - FAILs with 0x80000001 when used on `/proc/kmsg` or
+   `/dev/block/mmcblk0p44`. Works on a regular file though.
+
+The response matches the request (masked with 0x3).
+
+If the length is larger than somewhere between 227 MiB and 228 MiB, an
+0x80000001 error will be raised (observed with /dev/block/mmcblk0). Requesting
+lengths larger than 8 MiB however already seem to hang the communication. Length
+can be zero to test if a file is readable.
+
+This can be used to read already-opened files without authentication, but lafd
+seems to only have PNG files and `/dev/null` open by default. Attempting to read
+`/dev/null` hangs communication.
+
+### ERSE - Erase Block
+TRIMs a block (`IOCTL_TRIM_CMD`).
+
+Arguments:
+ - arg1: file descriptor (open `/dev/block/mmcblk0` for writing).
+ - arg2: start address (in sectors).
+ - arg3: count (in sectors).
+ - arg4: unknown, set to zero.
+
+Request body: none.
+
+Note: after sending TRIM, reading the block still returned old values. After a
+reboot, everything was zeroed out though.
+
+### EXEC - Execute Command
+Arguments: none
+
+Request body: NUL-terminated command, at most 255 bytes including terminator.
+
+Response body: standard output of the command.
+
+The command is split on spaces and then passed to `execvp`. In order to see
+standard error, use variables and globbing, use a command such as:
+
+    sh -c eval\t"$*"</dev/null\t2>&1 -- echo $PATH
+
+(replace `\t` by tabs)
+
+If you need to read dmesg (or other blocking files), try to put busybox on the
+device (e.g. by writing to an unused partition) and execute:
+
+    /data/busybox timeout -s 2 cat /proc/kmsg
+
+The maximum output size appears to be 0x800001 (`LAF_MAX_DATA_PAYLOAD`). Larger
+values result in an error. Output is read per byte, not very efficient for large
+output...
+
+On newer versions, this requires authentication via `KILO` command, and few
+commands are allowed.
+
+### INFO
+Arguments:
+ - arg1: action (`GPRO` - Get Properties, `SPRO` - Set Properties)
+
+Request body: a `laf_property` structure.
+
+Response body: 2824 (0x00000b08) bytes of binary info.
+
+See [scripts/parse-props.py](scripts/parse-props.py) for the structure of the
+property body. This structure begins with a DWORD with a version that is
+apparently the same as the expected length (2824 or `\x08\x0b\0\0`).
+
+### UNLK - Unlink
+Delete a file.
+
+Arguments: none
+
+Request body: NUL-terminated file name
+
+Responds with FAIL code 0x80000001 if the file name is invalid (missing) or
+file does not exist. Deleting directories is also not possible, giving the same
+FAIL code 0x80000001.
+
+### RSVD - Reserved
+Miscellaneous commands.
+
+Arguments:
+ - arg1: Subcommand:
+    - IDDD: create `/data/idt.cfg` ("indirect config file") and start IDT thread
+    - PDDD: unzip DF file
+    - QDDD: verify `/system/DFFileList.txt`
+    - RDDD: execute `/system/DFFileList.txt`
+    - SDDD: LCD test (turns screen grey)
+    - TDDD: set properties and disable USB:
+        - `ro.boot.laf = MID`
+        - `sys.usb.config = none`
+
+### IOCT - ioctl
+Perform flash IOCTLs. (XXX document this)
+
+### MISC
+Read/write misc parttition.
+
+Arguments:
+ - arg1: Subcommand
+    - `READ`
+    - `WRTE`
+
+XXX document this
+
+### KILO
+Challenge/response to authenticate for some commands.
+
+Arguments:
+ - arg1: `CENT` or `METR`
+ - arg2: challenge/mode
+
+1. Host sends `CENT` with arg2=0
+2. Device responds `CENT` with a random value in arg2
+3. Host responds `METR` with desired mode in arg2 and challenge response as body
+4. Device responds `METR` with no body, or `FAIL`
+
+The response must decrypt to the bytes
+`00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F`. TODO: explain protocol
+
+### DIFF
+Execute a script of some sort, path specified in message body.
+
+### SNIF
+Unknown / looks related to TOT download (TODO: document this)
+
+Arguments:
+ - arg1: Subcommand
+    - `REQS`
+    - `OPEN`
+    - `WRTE`
+    - `CLSE`
+    - `STUS`
+    - `IDDD`
+
+### OPCM
+Check/Write opcode
+
+NOTE: Supported since Protocol version `0x1000004`
+
+Arguments:
+ - arg1: action (`CHEK` - Check opcode, `WRTE` - Write opcode)
+
+### FUSE
+Get or set efuse(s) (TODO: document this)
+
+Arguments:
+ - arg1: action (`GFUS` - Get efuse state, `SFRS` - Set/blow efuse)
+
+### WRZR
+Write zeroes
+
+### CRCC
+Calculcate CRC (TODO: document this)
+
+### CHCK
+Unknown (TODO: document this)
+
+NOTE: Supported since Protocol version `0x1000003`
+
+Arguments:
+ - arg1: Subcommand
+    - `TSUM`
+    - `CLER`
+
+### SEBP
+Set eMMC boot partition (TODO: document this)
+
+### SBLU
+Set UFS boot LUN# (TODO: document this)
+
+### MBPT
+Manipulate boot partition table (TODO: document this)
+
+### FAIL
+Dummy command.
+
+### new versions
+TODO: document these commands added in some version:
+TOFF, COPY, SLEI, SIGN
+
+
+## HDLC commands
+These are sent through the same interface, but have a different structure:
+
+* The packet must be at least 3 and at most 31 bytes long.
+* The last byte must be 0x7E.
+* Any 0x7D byte is skipped; the next byte is then XORed with 0x20. eg 0x7D 0x5E
+  becomes 0x7E. (Not sure why this is done.)
+* The last two bytes of the body are a CRC16.
+
+After decoding, the body is checked for an 0x7E byte (except the very last byte
+of the packet); if one is found, all bytes up to and including it are discarded.
+This is done before the checksum is validated. (for example, 0x7E marks the
+beginning of the body, but can be omitted, in which case the body starts at the
+first byte of the packet.)
+
+The first byte of the body is a command:
+* 0x06: unknown. Always responds with 0x02?
+* 0x0A: Sets misc partition item 0x1C0 and reboots. (XXX investigate)
+* 0xEF: webdload_proc
+* 0xFA: testmode_proc
+
+Additionally, sending a packet which decodes to an empty body (for example, a
+packet of only `0x7E 0x7E 0x7E 0x7E`) restarts lafd. Unsure if this is
+intentional.
+
+### webdload_proc
+First byte of body (after 0xEF command byte) is subcommand:
+* 0x00: returns 0x05 and writes 0x04 at input[3]
+* 0xA0: returns device OS version, target operator, model, etc.
+* 0xA1, 0xA2, 0xB0, 0xB1, 0xB2, 0xB5: all return all-zero response.
+
+These appear to also read/write some misc partition values.
+
+### testmode_proc
+First two bytes (after 0xFA command byte) must be 0x94 0x00. Next byte after
+that is subcommand for `laf_testmode_bootloader_unlock_handler`:
+* 0x00: Check if unlocked. (`/sys/devices/platform/lge-msm8226-qfprom/unlock`
+  contains 0x277F.)
+* 0x01: Always returns 0.
+* 0x02: Reads hex from `/sys/devices/platform/lge-msm8226-qfprom/unlock-extra`.
+* 0x03: Read `/persist/rct`.
+
+Commands 0x00 and 0x02 don't work on some devices, since they have `lge-qfprom`
+instead of `lge-msm8226-qfprom` directory.
+
+#### Return data
+0xFA 0x94 0x00 followed by response body followed by CRC16 and 0x7E, encoded the
+same way as the command packet.
+
+First byte of response body is a status code:
+* 0x00: OK
+* 0x01: Failed
+* 0x02: Return from command 0x06 (might be LAF_ERROR_INVALID_PARAMETER? but it
+  can only ever return this.)
+* 0x05: Return from webdload_proc subcommand 0x00 (might be
+  LAF_ERROR_INTERNAL_ERROR?)
+* 0xFF: Invalid command
+
+Following response bytes depend on the command:
+* testmode_proc: null-terminated string (eg "lock", "unlock", "fail") followed
+  by unknown bytes (0x19 0xEA 0xE8 0x7F 0x00 0x00 observed)
+* webdload_proc: several strings of device info
+
+
+## Encoded commands
+For convenience, valid commands encoded with CRC:
+* 0xEF 0x00 0x00 0x00 0xAD 0xFA 0x7E
+* 0xEF 0xA0 0x00 0x00 0x7A 0xF5 0x7E
+* 0xEF 0xA1 0x00 0x00 0xA6 0xAF 0x7E
+* 0xEF 0xA2 0x00 0x00 0xC2 0x40 0x7E
+* 0xEF 0xB0 0x00 0x00 0xEF 0x70 0x7E
+* 0xEF 0xB1 0x00 0x00 0x33 0x2A 0x7E
+* 0xEF 0xB2 0x00 0x00 0x57 0xC5 0x7E
+* 0xEF 0xB5 0x00 0x00 0x52 0x49 0x7E
+* 0xFA 0x94 0x00 0x00 0x43 0xBD 0x7E
+* 0xFA 0x94 0x00 0x01 0xCA 0xAC 0x7E
+* 0xFA 0x94 0x00 0x02 0x51 0x9E 0x7E
+* 0xFA 0x94 0x00 0x03 0xD8 0x8F 0x7E
+* 0xFA 0x94 0x00 0x04 0x67 0xFB 0x7E
+
+
+## USB layer
+The LG Windows driver (via `LGMobileDriver_WHQL_Ver_4.0.3.exe`) exposes two
+serial ports, `LGANDNETMDM0` and `LGANDNETDIAG1`. The `LGANDNETDIAG1` port is
+used for LAF.
+
+The LG G3 (D855) has Vendor ID 0x1004 and Product ID 0x633e.
+
+There is only one configuration descriptor and LAF uses bulk transfers over
+endpoints 5 (for input from the device) and endpoint 3 (for output to the
+device).
+
+For other descriptors, see [info/lsusb.txt](info/lsusb.txt).

--- a/rules.d/42-usb-lglaf.rules
+++ b/rules.d/42-usb-lglaf.rules
@@ -1,0 +1,12 @@
+# /etc/udev/rules.d/42-usb-lglaf.rules
+# LG G3 (D855) or LG V10 (H962) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633e", TAG+="uaccess"
+# LG G3 (VS985) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="627f", TAG+="uaccess"
+# LG G4 (VS986) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="6298", TAG+="uaccess"
+# LG G3 (D852) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="633a", TAG+="uaccess"
+# LG K10 2017 (M250N) in download mode
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="6000", TAG+="uaccess"
+

--- a/scripts/parse-props.py
+++ b/scripts/parse-props.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Parse property file.
+#
+# Usage:
+#
+#   lglaf.py -c '!INFO GPRO \x08\x0b\0\0' > props.bin
+#   scripts/parse-props.py props.bin
+
+import argparse, sys, struct
+
+def stringify(resp):
+    if not isinstance(resp, str):
+        try: resp = resp.decode('ascii')
+        except: pass
+    return resp
+
+def get_str(data, shadow, offset):
+    resp = b''
+    #while True:
+    while offset < len(data):
+        b = data[offset:offset+1]
+        shadow[offset] = 's'
+        if b == b'\0':
+            break
+        resp += b
+        offset += 1
+    return stringify(resp)
+
+def get_chr(data, shadow, offset):
+    b = data[offset:offset+1]
+    shadow[offset] = 'c'
+    return stringify(b)
+
+def get_int(data, shadow, offset):
+    d = struct.unpack_from('<I', data, offset)[0]
+    for off in range(offset, offset+4):
+        shadow[off] = 'd'
+    return d
+
+# Description of the contents
+keys = [
+    (0x3f9, get_str, "download cable"),
+    (0x42b, get_int, "battery level"),
+    (0x010, get_chr, "download type"),
+    (0x021, get_int, "download speed"),
+    (0x403, get_str, "usb version"),
+    (0x417, get_str, "hardware revision"),
+    (0x029, get_str, "download sw version"),
+    (0x14f, get_str, "device sw version"),
+    (0x42f, get_chr, "secure device"),
+    (0x4e8, get_str, "laf sw version"),
+    (0x24f, get_str, "device factory version"),
+    (0x528, get_str, "device factory out version"),
+    (0x3db, get_str, "pid"),
+    (0x3c7, get_str, "imei"),
+    (0x131, get_str, "model name"),
+    (0x430, get_str, "device build type"),
+    (0x43a, get_str, "chipset platform"),
+    (0x44e, get_str, "target_operator"),
+    (0x462, get_str, "target_country"),
+    (0x4fc, get_int, "ap_factory_reset_status"),
+    (0x500, get_int, "cp_factory_reset_status"),
+    (0x504, get_int, "isDownloadNotFinish"),
+    (0x508, get_int, "qem"),
+    (0x628, get_str, "cupss swfv"),
+    (0x728, get_int, "is one binary dual plan"),
+    (0x72c, get_int, "memory size"),
+    (0x730, get_str, "memory_id"),
+    (0x39f, get_str, "bootloader_ver"),
+]
+
+def debug_other(data, shadow):
+    for offset, shadow_type in enumerate(shadow):
+        data_byte = data[offset:offset+1]
+        if not shadow_type and data_byte != b'\0':
+            print("Unprocessed byte at 0x%03x: %r" % (offset, data_byte))
+            shadow[offset] = '*'
+
+def print_shadow(shadow):
+    for offset in range(0, len(shadow), 32):
+        line1 = ''.join(c or '.' for c in shadow[offset:offset+16])
+        line2 = ''.join(c or '.' for c in shadow[offset+16:offset+32])
+        print("%03x: %-16s %-16s" % (offset, line1, line2))
+
+def parse_data(data):
+    version = struct.unpack_from('<I', data)[0]
+    expected_length = 0x00000b08
+    assert version == expected_length, 'Unknown version: 0x%08x' % version
+    assert len(data) == expected_length
+
+    # Set to non-None when processed
+    shadow = [None] * len(data)
+    for offset, getter, description in keys:
+        resp = getter(data, shadow, offset)
+        print("%-26s = %r" % (description, resp))
+
+    return data, shadow
+
+def open_local_readable(path):
+    if path == '-':
+        try: return sys.stdin.buffer
+        except: return sys.stdin
+    else:
+        return open(path, "rb")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--debug", action='store_true', help="Enable debug messages")
+parser.add_argument("file",
+        help="2824 byte properties dump file (or '-' for stdin)")
+
+def main():
+    args = parser.parse_args()
+    data = open_local_readable(args.file).read()
+    data, shadow = parse_data(data)
+    if args.debug:
+        debug_other(data, shadow)
+        print_shadow(shadow)
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.fixture(scope='session')
+def laf_key():
+    return b'qndiakxxuiemdklseqid~a~niq,zjuxl'

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,17 @@
+from binascii import unhexlify
+import laf_crypto
+
+
+def test_transform(laf_key):
+    transformed = laf_crypto.key_transform(laf_key)
+    assert transformed == b'dqoev)ohnsWu\\bk`oiicmZ_lpqe\\ealp'
+
+def test_xor_key(laf_key):
+    transformed_key = b'dqoev)ohnsWu\\bk`oiicmZ_lpqe\\ealp'
+    challenge = unhexlify(b'f29ae130')
+    xored_key = laf_crypto.xor_key(transformed_key, challenge)
+    assert xored_key == b'T\x90\xf5\x97F\xc8\xf5\x9a^\x92\xcd\x87l\x83\xf1\x92_\x88\xf3\x91]\xbb\xc5\x9e@\x90\xff\xaeU\x80\xf6\x82'
+
+def test_challenge(laf_key):
+    resp = laf_crypto.encrypt_kilo_challenge(laf_key, unhexlify(b'f29ae130'))
+    assert resp == unhexlify(b'2f47ca81ebeee6f414263c0542c8d132')


### PR DESCRIPTION
Replace deprecated `logger.warn()` with `logger.warning()`.